### PR TITLE
Drop the "main" task via kwarg idea

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
     - pip install . -r requirements-test.txt
 
 script:
-    - pytest tests/
+    - pytest tests/ --no-print-logs

--- a/tests/test_tractor.py
+++ b/tests/test_tractor.py
@@ -448,7 +448,7 @@ def test_a_quadruple_example():
     assert results
 
 
-@pytest.mark.parametrize('cancel_delay', list(range(1, 8)))
+@pytest.mark.parametrize('cancel_delay', list(range(1, 7)))
 def test_not_fast_enough_quad(cancel_delay):
     """Verify we can cancel midway through the quad example and all actors
     cancel gracefully.

--- a/tractor/__init__.py
+++ b/tractor/__init__.py
@@ -49,23 +49,22 @@ async def _main(async_fn, args, kwargs, name, arbiter_addr):
         log.info(f"Arbiter seems to exist @ {host}:{port}")
         actor = Actor(
             name or 'anonymous',
-            main=main,
             arbiter_addr=arbiter_addr,
             **kwargs
         )
         host, port = (host, 0)
     else:
         # start this local actor as the arbiter
-        # this should eventually get passed `outlive_main=True`?
         actor = Arbiter(
-            name or 'arbiter', main=main, arbiter_addr=arbiter_addr, **kwargs)
+            name or 'arbiter', arbiter_addr=arbiter_addr, **kwargs)
 
     # ``Actor._async_main()`` creates an internal nursery if one is not
     # provided and thus blocks here until it's main task completes.
     # Note that if the current actor is the arbiter it is desirable
     # for it to stay up indefinitely until a re-election process has
     # taken place - which is not implemented yet FYI).
-    return await _start_actor(actor, host, port, arbiter_addr=arbiter_addr)
+    return await _start_actor(
+        actor, main, host, port, arbiter_addr=arbiter_addr)
 
 
 def run(

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -624,11 +624,14 @@ async def _start_actor(actor, main, host, port, arbiter_addr, nursery=None):
                 arbiter_addr=arbiter_addr,
             )
         )
-        result = await main()
-        # XXX: If spawned locally, the actor is cancelled when this
-        # context is complete given that there are no more active
-        # peer channels connected to it.
-        actor.cancel_server()
+        if main is not None:
+            result = await main()
+            # XXX: If spawned with a dedicated "main function",
+            # the actor is cancelled when this context is complete
+            # given that there are no more active peer channels connected to it.
+            actor.cancel_server()
+
+    # block on actor to complete
 
     # unset module state
     _state._current_actor = None

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -282,10 +282,8 @@ class Actor:
                 if msg is None:  # terminate sentinel
                     log.debug(
                         f"Cancelling all tasks for {chan} from {chan.uid}")
-                    scopes = self._rpc_tasks.pop(chan, None)
-                    if scopes:
-                        for scope, func in scopes:
-                            scope.cancel()
+                    for scope, func in self._rpc_tasks.pop(chan, ()):
+                        scope.cancel()
 
                     log.debug(
                             f"Msg loop signalled to terminate for"


### PR DESCRIPTION
Stop worrying about a "main task" in each actor and instead add an
additional `ActorNursery.run_in_actor()` method which wraps calls
to create an actor and run a lone RPC task inside it. Note this
adjusts the public API of `ActorNursery.start_actor()` to drop
its `main` kwarg.

The dirty deats of making this possible:
- each spawned RPC task is now tracked with a specific cancel scope such
  that when the actor is cancelled all ongoing responders are cancelled
  before any IPC/channel machinery is closed (turns out that spawning
  new actors from `outlive_main=True` actors was probably borked before
  finally getting this working).
- make each initial RPC response be a packet which describes the
  `functype` (eg. `{'functype': 'asyncfunction'}`) allowing for async
  calls/submissions by client actors (this was required to make
  `run_in_actor()` work - `Portal._submit()` is the new async method).
- hooray we can stop faking "main task" results for daemon actors
- add better handling/raising of internal errors caught in the bowels of
  the `Actor` itself.
- drop the rpc spawning nursery; just use the `Actor._root_nursery`
- only wait on `_no_more_peers` if there are existing peer channels that
  are actually still connected.
- an `ActorNursery.__aexit__()` now implicitly waits on `Portal.result()` on close
  for each `run_in_actor()` spawned actor.
- handle cancelling partial started actors which haven't yet connected
  back to the parent

Resolves #24

This will require updates to #11 obviously.

ping @vodik!