### PR TITLE
Reliable cancel tests

### DIFF
--- a/tractor/_forkserver_hackzorz.py
+++ b/tractor/_forkserver_hackzorz.py
@@ -29,6 +29,8 @@ SIGNED_STRUCT = struct.Struct('q')     # large enough for pid_t
 
 class PatchedForkServer(ForkServer):
 
+    _forkserver_pid = None
+
     def connect_to_new_process(self, fds):
         '''Request forkserver to create a child process.
 


### PR DESCRIPTION
Tweak the cancel tests to use a delay based on a single successful run; the cancel delay should be less then the time it takes a run to complete. This should avoid flaky tests across python versions and environments.

Also included is a fix for py3.7 which ensures our overridden `forkserver.py` stuff is properly imported when the server is first spun up.