### PR TITLE
Add type annotations to most functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ install:
     - pip install -U . -r requirements-test.txt
 
 script:
+    - mypy tractor/  --ignore-missing-imports
     - pytest tests/ --no-print-logs

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-trio
 pdbpp
+mypy

--- a/tractor/__init__.py
+++ b/tractor/__init__.py
@@ -3,6 +3,7 @@ tractor: An actor model micro-framework built on
          ``trio`` and ``multiprocessing``.
 """
 from functools import partial
+import typing
 
 import trio
 
@@ -32,7 +33,13 @@ _default_arbiter_host = '127.0.0.1'
 _default_arbiter_port = 1616
 
 
-async def _main(async_fn, args, kwargs, name, arbiter_addr):
+async def _main(
+    async_fn: typing.Callable[..., typing.Awaitable],
+    args: tuple,
+    kwargs: dict,
+    name: str,
+    arbiter_addr: (str, int)
+) -> typing.Any:
     """Async entry point for ``tractor``.
     """
     log = get_logger('tractor')
@@ -73,11 +80,11 @@ async def _main(async_fn, args, kwargs, name, arbiter_addr):
 
 
 def run(
-    async_fn,
-    *args,
-    name=None,
-    arbiter_addr=(_default_arbiter_host, _default_arbiter_port),
-    **kwargs
+    async_fn: typing.Callable[..., typing.Awaitable],
+    *args: ...,
+    name: str = None,
+    arbiter_addr: (str, int) = (_default_arbiter_host, _default_arbiter_port),
+    **kwargs: ...
 ):
     """Run a trio-actor async function in process.
 

--- a/tractor/__init__.py
+++ b/tractor/__init__.py
@@ -5,7 +5,7 @@ tractor: An actor model micro-framework built on
 from functools import partial
 import typing
 
-import trio
+import trio  # type: ignore
 
 from .log import get_console_log, get_logger, get_loglevel
 from ._ipc import _connect_chan, Channel
@@ -35,10 +35,10 @@ _default_arbiter_port = 1616
 
 async def _main(
     async_fn: typing.Callable[..., typing.Awaitable],
-    args: tuple,
-    kwargs: dict,
+    args: typing.Tuple,
+    kwargs: typing.Dict[str, typing.Any],
     name: str,
-    arbiter_addr: (str, int)
+    arbiter_addr: typing.Tuple[str, int]
 ) -> typing.Any:
     """Async entry point for ``tractor``.
     """
@@ -81,10 +81,10 @@ async def _main(
 
 def run(
     async_fn: typing.Callable[..., typing.Awaitable],
-    *args: ...,
+    *args: typing.Tuple,
     name: str = None,
-    arbiter_addr: (str, int) = (_default_arbiter_host, _default_arbiter_port),
-    **kwargs: ...
+    arbiter_addr: typing.Tuple[str, int] = (_default_arbiter_host, _default_arbiter_port),
+    **kwargs: typing.Dict[str, typing.Any],
 ):
     """Run a trio-actor async function in process.
 

--- a/tractor/_forkserver_hackzorz.py
+++ b/tractor/_forkserver_hackzorz.py
@@ -2,6 +2,9 @@
 This is near-copy of the 3.8 stdlib's ``multiprocessing.forkserver.py``
 with some hackery to prevent any more then a single forkserver and
 semaphore tracker per ``MainProcess``.
+
+.. note:: There is no type hinting in this code base (yet) to remain as
+          a close as possible to upstream.
 """
 import os
 import socket

--- a/tractor/_forkserver_hackzorz.py
+++ b/tractor/_forkserver_hackzorz.py
@@ -15,15 +15,12 @@ import errno
 import selectors
 import warnings
 
-from multiprocessing import (
-    forkserver, semaphore_tracker, spawn, process, util,
-    connection
-)
+from multiprocessing import semaphore_tracker, spawn, process  # type: ignore
+from multiprocessing import forkserver, util, connection  # type: ignore
 from multiprocessing.forkserver import (
         ForkServer, MAXFDS_TO_SEND
-        # _serve_one,
 )
-from multiprocessing.context import reduction
+from multiprocessing.context import reduction  # type: ignore
 
 
 # taken from 3.8

--- a/tractor/_ipc.py
+++ b/tractor/_ipc.py
@@ -42,11 +42,11 @@ class StreamQueue:
                 yield packet
 
     @property
-    def laddr(self) -> (str, int):
+    def laddr(self) -> typing.Tuple[str, int]:
         return self._laddr
 
     @property
-    def raddr(self) -> (str, int):
+    def raddr(self) -> typing.Tuple[str, int]:
         return self._raddr
 
     async def put(self, data: typing.Any) -> int:
@@ -97,11 +97,11 @@ class Channel:
         return object.__repr__(self)
 
     @property
-    def laddr(self) -> (str, int):
+    def laddr(self) -> typing.Tuple[str, int]:
         return self.squeue.laddr if self.squeue else (None, None)
 
     @property
-    def raddr(self) -> (str, int):
+    def raddr(self) -> typing.Tuple[str, int]:
         return self.squeue.raddr if self.squeue else (None, None)
 
     async def connect(

--- a/tractor/_portal.py
+++ b/tractor/_portal.py
@@ -2,6 +2,7 @@
 Portal api
 """
 import importlib
+import typing
 
 import trio
 from async_generator import asynccontextmanager
@@ -18,7 +19,7 @@ class RemoteActorError(RuntimeError):
 
 
 @asynccontextmanager
-async def maybe_open_nursery(nursery=None):
+async def maybe_open_nursery(nursery: trio._core._run.Nursery = None):
     """Create a new nursery if None provided.
 
     Blocks on exit as expected if no input nursery is provided.
@@ -30,7 +31,7 @@ async def maybe_open_nursery(nursery=None):
             yield nursery
 
 
-async def _do_handshake(actor, chan):
+async def _do_handshake(actor: 'Actor', chan: 'Channel') -> (str, str):
     await chan.send(actor.uid)
     uid = await chan.recv()
 
@@ -51,7 +52,7 @@ class Portal:
 
     Think of this like an native async IPC API.
     """
-    def __init__(self, channel):
+    def __init__(self, channel: 'Channel'):
         self.channel = channel
         # when this is set to a tuple returned from ``_submit()`` then
         # it is expected that ``result()`` will be awaited at some point
@@ -60,13 +61,15 @@ class Portal:
         self._exc = None
         self._expect_result = None
 
-    async def aclose(self):
+    async def aclose(self) -> None:
         log.debug(f"Closing {self}")
         # XXX: won't work until https://github.com/python-trio/trio/pull/460
         # gets in!
         await self.channel.aclose()
 
-    async def _submit(self, ns, func, **kwargs):
+    async def _submit(
+        self, ns: str, func: str, **kwargs
+    ) -> (str, trio.Queue, str, dict):
         """Submit a function to be scheduled and run by actor, return the
         associated caller id, response queue, response type str,
         first message packet as a tuple.
@@ -93,12 +96,12 @@ class Portal:
 
         return cid, q, resp_type, first_msg
 
-    async def _submit_for_result(self, ns, func, **kwargs):
+    async def _submit_for_result(self, ns: str, func: str, **kwargs) -> None:
         assert self._expect_result is None, \
                 "A pending main result has already been submitted"
         self._expect_result = await self._submit(ns, func, **kwargs)
 
-    async def run(self, ns, func, **kwargs):
+    async def run(self, ns: str, func: str, **kwargs) -> typing.Any:
         """Submit a function to be scheduled and run by actor, wrap and return
         its (stream of) result(s).
 
@@ -108,7 +111,9 @@ class Portal:
             *(await self._submit(ns, func, **kwargs))
         )
 
-    async def _return_from_resptype(self, cid, q, resptype, first_msg):
+    async def _return_from_resptype(
+        self, cid: str, q: trio.Queue, resptype: str, first_msg: dict
+    ) -> typing.Any:
         # TODO: not this needs some serious work and thinking about how
         # to make async-generators the fundamental IPC API over channels!
         # (think `yield from`, `gen.send()`, and functional reactive stuff)
@@ -145,7 +150,7 @@ class Portal:
         else:
             raise ValueError(f"Unknown msg response type: {first_msg}")
 
-    async def result(self):
+    async def result(self) -> typing.Any:
         """Return the result(s) from the remote actor's "main" task.
         """
         if self._expect_result is None:
@@ -165,13 +170,13 @@ class Portal:
             )
         return self._result
 
-    async def close(self):
+    async def close(self) -> None:
         # trigger remote msg loop `break`
         chan = self.channel
         log.debug(f"Closing portal for {chan} to {chan.uid}")
         await self.channel.send(None)
 
-    async def cancel_actor(self):
+    async def cancel_actor(self) -> bool:
         """Cancel the actor on the other end of this portal.
         """
         log.warn(
@@ -198,10 +203,10 @@ class LocalPortal:
     A compatibility shim for normal portals but for invoking functions
     using an in process actor instance.
     """
-    def __init__(self, actor):
+    def __init__(self, actor: 'Actor'):
         self.actor = actor
 
-    async def run(self, ns, func, **kwargs):
+    async def run(self, ns: str, func: str, **kwargs) -> typing.Any:
         """Run a requested function locally and return it's result.
         """
         obj = self.actor if ns == 'self' else importlib.import_module(ns)
@@ -210,7 +215,10 @@ class LocalPortal:
 
 
 @asynccontextmanager
-async def open_portal(channel, nursery=None):
+async def open_portal(
+    channel: 'Channel',
+    nursery: trio._core._run.Nursery = None
+) -> typing.AsyncContextManager[Portal]:
     """Open a ``Portal`` through the provided ``channel``.
 
     Spawns a background task to handle message processing.

--- a/tractor/_portal.py
+++ b/tractor/_portal.py
@@ -31,7 +31,9 @@ async def maybe_open_nursery(nursery: trio._core._run.Nursery = None):
             yield nursery
 
 
-async def _do_handshake(actor: 'Actor', chan: 'Channel') -> (str, str):
+async def _do_handshake(
+    actor: 'Actor', chan: 'Channel'
+)-> typing.Tuple[str, str]:
     await chan.send(actor.uid)
     uid = await chan.recv()
 
@@ -69,7 +71,7 @@ class Portal:
 
     async def _submit(
         self, ns: str, func: str, **kwargs
-    ) -> (str, trio.Queue, str, dict):
+    ) -> typing.Tuple[str, trio.Queue, str, typing.Dict[str, typing.Any]]:
         """Submit a function to be scheduled and run by actor, return the
         associated caller id, response queue, response type str,
         first message packet as a tuple.

--- a/tractor/_state.py
+++ b/tractor/_state.py
@@ -1,10 +1,13 @@
 """
 Per process state
 """
-_current_actor = None
+from typing import Optional
 
 
-def current_actor() -> 'Actor':
+_current_actor: Optional['Actor'] = None  # type: ignore
+
+
+def current_actor() -> 'Actor':  # type: ignore
     """Get the process-local actor instance.
     """
     if not _current_actor:

--- a/tractor/log.py
+++ b/tractor/log.py
@@ -92,5 +92,5 @@ def get_console_log(level: str = None, name: str = None) -> logging.Logger:
     return log
 
 
-def get_loglevel():
+def get_loglevel() -> str:
     return _default_loglevel

--- a/tractor/log.py
+++ b/tractor/log.py
@@ -2,9 +2,10 @@
 Log like a forester!
 """
 from functools import partial
-import sys
 import logging
 import colorlog  # type: ignore
+from typing import Optional
+
 
 _proj_name = 'tractor'
 _default_loglevel = None
@@ -86,5 +87,5 @@ def get_console_log(level: str = None, name: str = None) -> logging.Logger:
     return log
 
 
-def get_loglevel() -> str:
+def get_loglevel() -> Optional[str]:
     return _default_loglevel

--- a/tractor/log.py
+++ b/tractor/log.py
@@ -4,7 +4,7 @@ Log like a forester!
 from functools import partial
 import sys
 import logging
-import colorlog
+import colorlog  # type: ignore
 
 _proj_name = 'tractor'
 _default_loglevel = None
@@ -69,25 +69,19 @@ def get_console_log(level: str = None, name: str = None) -> logging.Logger:
     log = get_logger(name)  # our root logger
 
     if not level:
-        return
+        return log
 
     log.setLevel(level.upper() if not isinstance(level, int) else level)
-
-    if not any(
-        handler.stream == sys.stderr for handler in log.handlers
-        if getattr(handler, 'stream', None)
-    ):
-        handler = logging.StreamHandler()
-
-        formatter = colorlog.ColoredFormatter(
-            LOG_FORMAT,
-            datefmt=DATE_FORMAT,
-            log_colors=STD_PALETTE,
-            secondary_log_colors=BOLD_PALETTE,
-            style='{',
-        )
-        handler.setFormatter(formatter)
-        log.addHandler(handler)
+    handler = logging.StreamHandler()
+    formatter = colorlog.ColoredFormatter(
+        LOG_FORMAT,
+        datefmt=DATE_FORMAT,
+        log_colors=STD_PALETTE,
+        secondary_log_colors=BOLD_PALETTE,
+        style='{',
+    )
+    handler.setFormatter(formatter)
+    log.addHandler(handler)
 
     return log
 


### PR DESCRIPTION
This is purely for documentation purposes for now as it should be
obvious a bunch of the signatures aren't using the correct "generics"
syntax (i.e. the use of `(str, int)` instead of `typing.Tuple[str, int])`)
in a bunch of places. We're also not using a type checker yet and besides,
`trio` doesn't really expose a lot of its internal types very well.

cc @vodik