### PR TITLE
Improved errors - introduce trio.MultiError

### DIFF
--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -162,11 +162,14 @@ async def test_some_cancels_all(num_actors_and_errs):
         # ``MultiError`` containing an ``AssertionError`
 
     except first_err as err:
-        if isinstance(err, trio.MultiError):
+        if isinstance(err, tractor.MultiError):
             assert len(err.exceptions) == num
             for exc in err.exceptions:
-                assert exc.type == err_type
-        else:
+                if isinstance(exc, tractor.RemoteActorError):
+                    assert exc.type == err_type
+                else:
+                    assert isinstance(exc, trio.Cancelled)
+        elif isinstance(err, tractor.RemoteActorError):
             assert err.type == err_type
 
         assert n.cancelled is True

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -14,26 +14,65 @@ async def assert_err():
     assert 0
 
 
-def test_remote_error(arb_addr):
-    """Verify an error raises in a subactor is propagated to the parent.
+@pytest.mark.parametrize(
+    'args_err',
+    [
+        # expected to be thrown in assert_err
+        ({}, AssertionError),
+        # argument mismatch raised in _invoke()
+        ({'unexpected': 10}, TypeError)
+    ],
+    ids=['no_args', 'unexpected_args'],
+)
+def test_remote_error(arb_addr, args_err):
+    """Verify an error raised in a subactor that is propagated
+    to the parent nursery, contains underlying builtin erorr type
+    infot and causes cancellation and reraising.
+    """
+    args, errtype = args_err
+
+    async def main():
+        async with tractor.open_nursery() as nursery:
+
+            portal = await nursery.run_in_actor('errorer', assert_err, **args)
+
+            # get result(s) from main task
+            try:
+                await portal.result()
+            except tractor.RemoteActorError as err:
+                assert err.type == errtype
+                print("Look Maa that actor failed hard, hehh")
+                raise
+            else:
+                assert 0, "Remote error was not raised?"
+
+    with pytest.raises(tractor.RemoteActorError):
+        # also raises
+        tractor.run(main, arbiter_addr=arb_addr)
+
+
+def test_multierror(arb_addr):
+    """Verify we raise a ``trio.MultiError`` out of a nursery where
+    more then one actor errors.
     """
     async def main():
         async with tractor.open_nursery() as nursery:
 
-            portal = await nursery.run_in_actor('errorer', assert_err)
+            await nursery.run_in_actor('errorer1', assert_err)
+            portal2 = await nursery.run_in_actor('errorer2', assert_err)
 
             # get result(s) from main task
             try:
-                return await portal.result()
-            except tractor.RemoteActorError:
-                print("Look Maa that actor failed hard, hehh")
+                await portal2.result()
+            except tractor.RemoteActorError as err:
+                assert err.type == AssertionError
+                print("Look Maa that first actor failed hard, hehh")
                 raise
-            except Exception:
-                pass
-            assert 0, "Remote error was not raised?"
 
-    with pytest.raises(tractor.RemoteActorError):
-        # also raises
+        # here we should get a `trio.MultiError` containing exceptions
+        # from both subactors
+
+    with pytest.raises(trio.MultiError):
         tractor.run(main, arbiter_addr=arb_addr)
 
 
@@ -42,9 +81,12 @@ def do_nothing():
 
 
 def test_cancel_single_subactor(arb_addr):
-
-    async def main():
-
+    """Ensure a ``ActorNursery.start_actor()`` spawned subactor
+    cancels when the nursery is cancelled.
+    """
+    async def spawn_actor():
+        """Spawn an actor that blocks indefinitely.
+        """
         async with tractor.open_nursery() as nursery:
 
             portal = await nursery.start_actor(
@@ -55,7 +97,7 @@ def test_cancel_single_subactor(arb_addr):
             # would hang otherwise
             await nursery.cancel()
 
-    tractor.run(main, arbiter_addr=arb_addr)
+    tractor.run(spawn_actor, arbiter_addr=arb_addr)
 
 
 async def stream_forever():
@@ -87,13 +129,22 @@ async def test_cancel_infinite_streamer():
     assert n.cancelled
 
 
+@pytest.mark.parametrize(
+    'num_actors_and_errs',
+    [
+        (1, tractor.RemoteActorError, AssertionError),
+        (2, tractor.MultiError, AssertionError)
+    ],
+    ids=['one_actor', 'two_actors'],
+)
 @tractor_test
-async def test_one_cancels_all():
+async def test_some_cancels_all(num_actors_and_errs):
     """Verify one failed actor causes all others in the nursery
     to be cancelled just like in trio.
 
     This is the first and only supervisory strategy at the moment.
     """
+    num, first_err, err_type = num_actors_and_errs
     try:
         async with tractor.open_nursery() as n:
             real_actors = []
@@ -103,13 +154,21 @@ async def test_one_cancels_all():
                     rpc_module_paths=[__name__],
                 ))
 
-            # start one actor that will fail immediately
-            await n.run_in_actor('extra', assert_err)
+            for i in range(num):
+                # start one actor that will fail immediately
+                await n.run_in_actor(f'extra_{i}', assert_err)
 
-        # should error here with a ``RemoteActorError`` containing
-        # an ``AssertionError`
+        # should error here with a ``RemoteActorError`` or
+        # ``MultiError`` containing an ``AssertionError`
 
-    except tractor.RemoteActorError:
+    except first_err as err:
+        if isinstance(err, trio.MultiError):
+            assert len(err.exceptions) == num
+            for exc in err.exceptions:
+                assert exc.type == err_type
+        else:
+            assert err.type == err_type
+
         assert n.cancelled is True
         assert not n._children
     else:

--- a/tests/test_multi_program.py
+++ b/tests/test_multi_program.py
@@ -41,7 +41,7 @@ def daemon(loglevel, testdir, arb_addr):
         stderr=subprocess.PIPE,
     )
     assert not proc.returncode
-    wait = 0.6 if sys.version_info < (3, 7) else 0.2
+    wait = 0.6 if sys.version_info < (3, 7) else 0.4
     time.sleep(wait)
     yield proc
     sig_prog(proc, signal.SIGINT)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -166,7 +166,7 @@ def test_a_quadruple_example(time_quad_ex):
 
 @pytest.mark.parametrize(
     'cancel_delay',
-    list(map(lambda i: i/10, range(2, 8)))
+    list(map(lambda i: i/10, range(3, 9)))
 )
 def test_not_fast_enough_quad(arb_addr, time_quad_ex, cancel_delay):
     """Verify we can cancel midway through the quad example and all actors

--- a/tractor/__init__.py
+++ b/tractor/__init__.py
@@ -16,7 +16,7 @@ from ._actor import (
 )
 from ._trionics import open_nursery
 from ._state import current_actor
-from ._portal import RemoteActorError
+from ._exceptions import RemoteActorError
 
 
 __all__ = [

--- a/tractor/__init__.py
+++ b/tractor/__init__.py
@@ -4,10 +4,11 @@ tractor: An actor model micro-framework built on
 """
 import importlib
 from functools import partial
-from typing import Tuple, Any, Optional
+from typing import Tuple, Any
 import typing
 
 import trio  # type: ignore
+from trio import MultiError
 
 from .log import get_console_log, get_logger, get_loglevel
 from ._ipc import _connect_chan, Channel
@@ -23,10 +24,11 @@ __all__ = [
     'current_actor',
     'find_actor',
     'get_arbiter',
-    'wait_for_actor',
     'open_nursery',
-    'RemoteActorError',
+    'wait_for_actor',
     'Channel',
+    'MultiError',
+    'RemoteActorError',
 ]
 
 

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -125,8 +125,11 @@ async def _invoke(
         log.exception("Actor errored:")
         err_msg = pack_error(err)
         err_msg['cid'] = cid
-        await chan.send(err_msg)
-
+        try:
+            await chan.send(err_msg)
+        except trio.ClosedResourceError:
+            log.exception(
+                f"Failed to ship error to caller @ {chan.uid}")
         if cs is None:
             # error is from above code not from rpc invocation
             task_status.started(err)

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -357,10 +357,10 @@ class Actor:
                     # (i.e. no cid was provided in the msg - see above).
                     # Push this error to all local channel consumers
                     # (normally portals) by marking the channel as errored
-                    tb_str = msg.pop('tb_str')
+                    tb_str = msg.get('tb_str')
                     assert chan.uid
                     exc = InternalActorError(
-                        f"{self.channel.uid}\n" + tb_str,
+                        f"{chan.uid}\n" + tb_str,
                         **msg,
                     )
                     chan._exc = exc

--- a/tractor/_exceptions.py
+++ b/tractor/_exceptions.py
@@ -1,0 +1,50 @@
+"""
+Our classy exception set.
+"""
+import builtins
+import traceback
+
+
+class RemoteActorError(Exception):
+    # TODO: local recontruction of remote exception deats
+    "Remote actor exception bundled locally"
+    def __init__(self, message, type_str, **msgdata):
+        super().__init__(message)
+        self.type = getattr(builtins, type_str, Exception)
+        self.msgdata = msgdata
+
+    # TODO: a trio.MultiError.catch like context manager
+    # for catching underlying remote errors of a particular type
+
+
+class InternalActorError(RemoteActorError):
+    """Remote internal ``tractor`` error indicating
+    failure of some primitive or machinery.
+    """
+
+
+class NoResult(RuntimeError):
+    "No final result is expected for this actor"
+
+
+def pack_error(exc):
+    """Create an "error message" for tranmission over
+    a channel (aka the wire).
+    """
+    return {
+        'error': {
+            'tb_str': traceback.format_exc(),
+            'type_str': type(exc).__name__,
+        }
+    }
+
+
+def unpack_error(msg, chan=None):
+    """Unpack an 'error' message from the wire
+    into a local ``RemoteActorError``.
+    """
+    tb_str = msg['error'].get('tb_str', '')
+    return RemoteActorError(
+        f"{chan.uid}\n" + tb_str,
+        **msg['error'],
+    )

--- a/tractor/_portal.py
+++ b/tractor/_portal.py
@@ -60,7 +60,7 @@ class Portal:
         # when this is set to a tuple returned from ``_submit()`` then
         # it is expected that ``result()`` will be awaited at some point
         # during the portal's lifetime
-        self._result = None
+        self._result: Optional[Any] = None
         # set when _submit_for_result is called
         self._expect_result: Optional[
             Tuple[str, Any, str, Dict[str, Any]]

--- a/tractor/_trionics.py
+++ b/tractor/_trionics.py
@@ -334,7 +334,7 @@ class ActorNursery:
             log.debug(f"Waiting on subactors {self._children} to complete")
             try:
                 await self.wait()
-            except Exception as err:
+            except (Exception, trio.MultiError) as err:
                 log.warning(f"Nursery caught {err}, cancelling")
                 await self.cancel()
                 raise

--- a/tractor/_trionics.py
+++ b/tractor/_trionics.py
@@ -222,7 +222,7 @@ class ActorNursery:
 
         log.debug(f"Waiting on all subactors to complete")
         children = self._children.copy()
-        errors = []
+        errors: List[Exception] = []
         # wait on run_in_actor() tasks, unblocks when all complete
         async with trio.open_nursery() as nursery:
             for subactor, proc, portal in children.values():

--- a/tractor/_trionics.py
+++ b/tractor/_trionics.py
@@ -32,7 +32,8 @@ class ActorNursery:
             Tuple[str, str],
             Tuple[Actor, mp.Process, Optional[Portal]]
         ] = {}
-        # portals spawned with ``run_in_actor()``
+        # portals spawned with ``run_in_actor()`` are
+        # cancelled when their "main" result arrives
         self._cancel_after_result_on_exit: set = set()
         self.cancelled: bool = False
         self._forkserver: forkserver.ForkServer = None
@@ -132,6 +133,8 @@ class ActorNursery:
             bind_addr=bind_addr,
             statespace=statespace,
         )
+        # this marks the actor to be cancelled after its portal result
+        # is retreived, see ``wait()`` below.
         self._cancel_after_result_on_exit.add(portal)
         await portal._submit_for_result(
             mod_path,
@@ -142,29 +145,65 @@ class ActorNursery:
 
     async def wait(self) -> None:
         """Wait for all subactors to complete.
+
+        This is probably the most complicated (and confusing, sorry)
+        function that does all the clever crap to deal with cancellation,
+        error propagation, and graceful subprocess tear down.
         """
-        async def maybe_consume_result(portal, actor):
-            if (
-                portal in self._cancel_after_result_on_exit and
-                (portal._result is None and portal._exc is None)
-            ):
-                log.debug(f"Waiting on final result from {subactor.uid}")
-                res = await portal.result()
-                # if it's an async-gen then we should alert the user
-                # that we're cancelling it
+        async def exhaust_portal(portal, actor):
+            """Pull final result from portal (assuming it was one).
+
+            If the main task is an async generator do our best to consume
+            what's left of it.
+            """
+            try:
+                log.debug(f"Waiting on final result from {actor.uid}")
+                final = res = await portal.result()
+                # if it's an async-gen then alert that we're cancelling it
                 if inspect.isasyncgen(res):
+                    final = []
                     log.warning(
                         f"Blindly consuming asyncgen for {actor.uid}")
                     with trio.fail_after(1):
                         async with aclosing(res) as agen:
                             async for item in agen:
                                 log.debug(f"Consuming item {item}")
+                                final.append(item)
+            except Exception as err:
+                # we reraise in the parent task via a ``trio.MultiError``
+                return err
+            else:
+                return final
+
+        async def cancel_on_completion(
+            portal: Portal,
+            actor: Actor,
+            task_status=trio.TASK_STATUS_IGNORED,
+        ) -> None:
+            """Cancel actor gracefully once it's "main" portal's
+            result arrives.
+
+            Should only be called for actors spawned with `run_in_actor()`.
+            """
+            with trio.open_cancel_scope() as cs:
+                task_status.started(cs)
+                # this may error in which case we expect the far end
+                # actor to have already terminated itself
+                result = await exhaust_portal(portal, actor)
+                if isinstance(result, Exception):
+                    errors.append(result)
+                log.info(f"Cancelling {portal.channel.uid} gracefully")
+                await portal.cancel_actor()
+
+            if cs.cancelled_caught:
+                log.warning(
+                    "Result waiter was cancelled, process may have died")
 
         async def wait_for_proc(
             proc: mp.Process,
             actor: Actor,
             portal: Portal,
-            cancel_scope: trio._core._run.CancelScope,
+            cancel_scope: Optional[trio._core._run.CancelScope] = None,
         ) -> None:
             # TODO: timeout block here?
             if proc.is_alive():
@@ -172,42 +211,57 @@ class ActorNursery:
             # please god don't hang
             proc.join()
             log.debug(f"Joined {proc}")
-            await maybe_consume_result(portal, actor)
-
             self._children.pop(actor.uid)
-            # proc terminated, cancel result waiter
+
+            # proc terminated, cancel result waiter that may have
+            # been spawned in tandem
             if cancel_scope:
                 log.warning(
                     f"Cancelling existing result waiter task for {actor.uid}")
                 cancel_scope.cancel()
 
-        async def wait_for_actor(
-            portal: Portal,
-            actor: Actor,
-            task_status=trio.TASK_STATUS_IGNORED,
-        ) -> None:
-            # cancel the actor gracefully
-            with trio.open_cancel_scope() as cs:
-                task_status.started(cs)
-                await maybe_consume_result(portal, actor)
-                log.info(f"Cancelling {portal.channel.uid} gracefully")
-                await portal.cancel_actor()
-
-            if cs.cancelled_caught:
-                log.warning("Result waiter was cancelled")
-
-        # unblocks when all waiter tasks have completed
+        log.debug(f"Waiting on all subactors to complete")
         children = self._children.copy()
+        errors = []
+        # wait on run_in_actor() tasks, unblocks when all complete
         async with trio.open_nursery() as nursery:
             for subactor, proc, portal in children.values():
                 cs = None
+                # portal from ``run_in_actor()``
                 if portal in self._cancel_after_result_on_exit:
-                    cs = await nursery.start(wait_for_actor, portal, subactor)
+                    cs = await nursery.start(
+                        cancel_on_completion, portal, subactor)
+                    # TODO: how do we handle remote host spawned actors?
+                    nursery.start_soon(
+                        wait_for_proc, proc, subactor, portal, cs)
+
+        if errors:
+            if not self.cancelled:
+                # halt here and expect to be called again once the nursery
+                # has been cancelled externally (ex. from within __aexit__()
+                # if an error is captured from ``wait()`` then ``cancel()``
+                # is called immediately after which in turn calls ``wait()``
+                # again.)
+                raise trio.MultiError(errors)
+
+        # wait on all `start_actor()` subactors to complete
+        # if errors were captured above and we have not been cancelled
+        # then these ``start_actor()`` spawned actors will block until
+        # cancelled externally
+        children = self._children.copy()
+        async with trio.open_nursery() as nursery:
+            for subactor, proc, portal in children.values():
+                # TODO: how do we handle remote host spawned actors?
                 nursery.start_soon(wait_for_proc, proc, subactor, portal, cs)
+
+        log.debug(f"All subactors for {self} have terminated")
+        if errors:
+            # always raise any error if we're also cancelled
+            raise trio.MultiError(errors)
 
     async def cancel(self, hard_kill: bool = False) -> None:
         """Cancel this nursery by instructing each subactor to cancel
-        iteslf and wait for all subprocesses to terminate.
+        itself and wait for all subactors to terminate.
 
         If ``hard_killl`` is set to ``True`` then kill the processes
         directly without any far end graceful ``trio`` cancellation.
@@ -234,56 +288,57 @@ class ActorNursery:
                             # channel/portal should now be up
                             _, _, portal = self._children[subactor.uid]
                             if portal is None:
-                                # cancelled while waiting on the event?
+                                # cancelled while waiting on the event
+                                # to arrive
                                 chan = self._actor._peers[subactor.uid][-1]
                                 if chan:
                                     portal = Portal(chan)
                                 else:  # there's no other choice left
                                     do_hard_kill(proc)
 
-                        # spawn cancel tasks async
+                        # spawn cancel tasks
                         assert portal
                         n.start_soon(portal.cancel_actor)
 
-        log.debug(f"Waiting on all subactors to complete")
-        await self.wait()
+        # mark ourselves as having (tried to have) cancelled all subactors
         self.cancelled = True
-        log.debug(f"All subactors for {self} have terminated")
+        await self.wait()
 
     async def __aexit__(self, etype, value, tb):
         """Wait on all subactor's main routines to complete.
         """
-        try:
-            if etype is not None:
+        if etype is not None:
+            try:
                 # XXX: hypothetically an error could be raised and then
-                # a cancel signal shows up slightly after in which case the
-                # else block here might not complete? Should both be shielded?
+                # a cancel signal shows up slightly after in which case
+                # the `else:` block here might not complete?
+                # For now, shield both.
                 with trio.open_cancel_scope(shield=True):
                     if etype is trio.Cancelled:
                         log.warning(
-                            f"{current_actor().uid} was cancelled with {etype}"
-                            ", cancelling actor nursery")
-                        await self.cancel()
+                            f"Nursery for {current_actor().uid} was "
+                            f"cancelled with {etype}")
                     else:
                         log.exception(
-                            f"{current_actor().uid} errored with {etype}, "
-                            "cancelling actor nursery")
-                        await self.cancel()
-            else:
-                # XXX: this is effectively the lone cancellation/supervisor
-                # strategy which exactly mimicks trio's behaviour
-                log.debug(f"Waiting on subactors {self._children} to complete")
-                try:
-                    await self.wait()
-                except Exception as err:
-                    log.warning(f"Nursery caught {err}, cancelling")
+                            f"Nursery for {current_actor().uid} "
+                            f"errored with {etype}, ")
                     await self.cancel()
-                    raise
-                log.debug(f"Nursery teardown complete")
-        except Exception:
-            log.exception("Error on nursery exit:")
-            await self.wait()
-            raise
+            except trio.MultiError as merr:
+                if value not in merr.exceptions:
+                    raise trio.MultiError(merr.exceptions + [value])
+                raise
+        else:
+            # XXX: this is effectively the (for now) lone
+            # cancellation/supervisor strategy which exactly
+            # mimicks trio's behaviour
+            log.debug(f"Waiting on subactors {self._children} to complete")
+            try:
+                await self.wait()
+            except Exception as err:
+                log.warning(f"Nursery caught {err}, cancelling")
+                await self.cancel()
+                raise
+            log.debug(f"Nursery teardown complete")
 
 
 @asynccontextmanager
@@ -297,3 +352,8 @@ async def open_nursery() -> typing.AsyncGenerator[ActorNursery, None]:
     # TODO: figure out supervisors from erlang
     async with ActorNursery(current_actor()) as nursery:
         yield nursery
+
+
+def is_main_process():
+    "Bool determining if this actor is running in the top-most process."
+    return mp.current_process().name == 'MainProcess'


### PR DESCRIPTION
This overhauls the cancellation / error propagation machinery:

- Unwrap remote error types and try to map them to a local type (still haven't quite figured out an API for catching such boxed error types but it might eventually look something like [MultiError.catch()](https://trio.readthedocs.io/en/latest/reference-core.html#trio.MultiError.catch))
- full `ActorNursery` support for [`trio.MultiError`](https://trio.readthedocs.io/en/latest/reference-core.html#trio.MultiError) and multi-actor errors with the [same semantics as `trio`](https://trio.readthedocs.io/en/latest/reference-core.html#errors-in-multiple-child-tasks)
- clearer distinction between internal `tractor._exceptions.InternalActorError` and remote errors, the former being raised when there's bugs in `tractor` internals

@vodik @Konstantine00 ping!