### PR TITLE
Expose `tractor_test` for external use

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     platforms=['linux'],
     packages=[
         'tractor',
+        'tractor.testing',
     ],
     install_requires=['msgpack', 'trio>0.8', 'async_generator', 'colorlog'],
     tests_require=['pytest'],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,10 @@
 ``tractor`` testing!!
 """
 import random
-from functools import partial, wraps
 
 import pytest
 import tractor
+from tractor._tractor_test import tractor_test
 
 
 pytest_plugins = ['pytester']
@@ -28,20 +28,3 @@ def loglevel(request):
 @pytest.fixture(scope='session')
 def arb_addr():
     return _arb_addr
-
-
-def tractor_test(fn):
-    """
-    Use:
-
-    @tractor_test
-    async def test_whatever():
-        await ...
-    """
-    @wraps(fn)
-    def wrapper(*args, **kwargs):
-        # __tracebackhide__ = True
-        return tractor.run(
-            partial(fn, *args, **kwargs), arbiter_addr=_arb_addr)
-
-    return wrapper

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import random
 
 import pytest
 import tractor
-from tractor._tractor_test import tractor_test
+from tractor.testing import tractor_test
 
 
 pytest_plugins = ['pytester']

--- a/tractor/_tractor_test.py
+++ b/tractor/_tractor_test.py
@@ -1,0 +1,26 @@
+import inspect
+from functools import partial, wraps
+
+from . import run
+
+
+def tractor_test(fn):
+    """
+    Use:
+
+    @tractor_test
+    async def test_whatever():
+        await ...
+
+    If an ``arb_addr`` (a socket addr tuple) is defined in the
+    `pytest` fixture space it will be automatically injected.
+    """
+    @wraps(fn)
+    def wrapper(*args, arb_addr=None, **kwargs):
+        # __tracebackhide__ = True
+        if 'arb_addr' in inspect.signature(fn).parameters:
+            kwargs['arb_addr'] = arb_addr
+        return run(
+            partial(fn, *args, **kwargs), arbiter_addr=arb_addr)
+
+    return wrapper

--- a/tractor/testing/__init__.py
+++ b/tractor/testing/__init__.py
@@ -1,0 +1,1 @@
+from ._tractor_test import tractor_test

--- a/tractor/testing/_tractor_test.py
+++ b/tractor/testing/_tractor_test.py
@@ -1,7 +1,10 @@
 import inspect
 from functools import partial, wraps
 
-from . import run
+from .. import run
+
+
+__all__ = ['tractor_test']
 
 
 def tractor_test(fn):


### PR DESCRIPTION
Copy the way `trio` does it. Adjust tests to match.