### PR TITLE
Support `loglevel` fixture injection

### DIFF
--- a/tractor/testing/_tractor_test.py
+++ b/tractor/testing/_tractor_test.py
@@ -15,15 +15,28 @@ def tractor_test(fn):
     async def test_whatever():
         await ...
 
-    If an ``arb_addr`` (a socket addr tuple) is defined in the
-    `pytest` fixture space it will be automatically injected.
+    If fixtures:
+
+        - ``arb_addr`` (a socket addr tuple where arbiter is listening)
+        - ``loglevel`` (logging level passed to tractor internals)
+
+    are defined in the `pytest` fixture space they will be automatically
+    injected to tests declaring these funcargs.
     """
     @wraps(fn)
-    def wrapper(*args, arb_addr=None, **kwargs):
+    def wrapper(*args, loglevel=None, arb_addr=None, **kwargs):
         # __tracebackhide__ = True
         if 'arb_addr' in inspect.signature(fn).parameters:
+            # injects test suite fixture value to test as well
+            # as `run()`
             kwargs['arb_addr'] = arb_addr
+        if 'loglevel' in inspect.signature(fn).parameters:
+            # allows test suites to define a 'loglevel' fixture
+            # that activates the internal logging
+            kwargs['loglevel'] = loglevel
         return run(
-            partial(fn, *args, **kwargs), arbiter_addr=arb_addr)
+            partial(fn, *args, **kwargs),
+            arbiter_addr=arb_addr, loglevel=loglevel
+        )
 
     return wrapper


### PR DESCRIPTION
For `pytest`, support defining a `loglevel` fixture value which will be
passed into internals when using `@tractor_test`.