### PR TITLE
Contexts and Pub-Sub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 matrix:
     include:
-        - python: 3.6
+        # - python: 3.6
         - python: 3.7
           dist: xenial
           sudo: required

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ down. A great place to start is the `trio docs`_ and this `blog post`_.
 .. _modern async Python: https://www.python.org/dev/peps/pep-0525/
 
 
-.. contents::  Table of Contents
+.. contents::
 
 
 Philosophy
@@ -64,6 +64,7 @@ Philosophy
 .. _pulsar: http://quantmind.github.io/pulsar/design.html
 .. _execnet: https://codespeak.net/execnet/
 
+
 Install
 -------
 No PyPi release yet!
@@ -73,8 +74,12 @@ No PyPi release yet!
     pip install git+git://github.com/tgoodlet/tractor.git
 
 
+Examples
+--------
+
+
 A trynamic first scene
-----------------------
+**********************
 Let's direct a couple *actors* and have them run their lines for
 the hip new film we're shooting:
 
@@ -131,7 +136,7 @@ this case our "director" executing ``main()``).
 
 
 Actor spawning and causality
-----------------------------
+****************************
 ``tractor`` tries to take ``trio``'s concept of causal task lifetimes
 to multi-process land. Accordingly, ``tractor``'s *actor nursery* behaves
 similar to ``trio``'s nursery_. That is, ``tractor.open_nursery()``
@@ -258,7 +263,7 @@ to all others with ease over standard network protocols).
 
 
 Async IPC using *portals*
--------------------------
+*************************
 ``tractor`` introduces the concept of a *portal* which is an API
 borrowed_ from ``trio``. A portal may seem similar to the idea of
 a RPC future_ except a *portal* allows invoking remote *async* functions and
@@ -324,6 +329,9 @@ generator function running in a separate actor:
     tractor.run(main)
 
 
+
+A full fledged streaming service
+********************************
 Alright, let's get fancy.
 
 Say you wanted to spawn two actors which each pull data feeds from
@@ -445,7 +453,7 @@ as ``multiprocessing`` calls it) which is running ``main()``.
 
 
 Cancellation
-------------
+************
 ``tractor`` supports ``trio``'s cancellation_ system verbatim.
 Cancelling a nursery block cancels all actors spawned by it.
 Eventually ``tractor`` plans to support different `supervision strategies`_ like ``erlang``.
@@ -454,7 +462,7 @@ Eventually ``tractor`` plans to support different `supervision strategies`_ like
 
 
 Remote error propagation
-------------------------
+************************
 Any task invoked in a remote actor should ship any error(s) back to the calling
 actor where it is raised and expected to be dealt with. This way remote actors
 are never cancelled unless explicitly asked or there's a bug in ``tractor`` itself.
@@ -497,7 +505,7 @@ a ``Supervisor`` type.
 
 
 Actor local variables
----------------------
+*********************
 Although ``tractor`` uses a *shared-nothing* architecture between processes
 you can of course share state between tasks running *within* an actor.
 ``trio`` tasks spawned via multiple RPC calls to an actor can access global
@@ -530,7 +538,7 @@ out a state sharing system per-actor is totally up to you.
 
 
 How do actors find each other (a poor man's *service discovery*)?
------------------------------------------------------------------
+*****************************************************************
 Though it will be built out much more in the near future, ``tractor``
 currently keeps track of actors by ``(name: str, id: str)`` using a
 special actor called the *arbiter*. Currently the *arbiter* must exist
@@ -564,7 +572,7 @@ The ``name`` value you should pass to ``find_actor()`` is the one you passed as 
 
 
 Streaming using channels and contexts
--------------------------------------
+*************************************
 ``Channel`` is the API which wraps an underlying *transport* and *interchange*
 format to enable *inter-actor-communication*. In its present state ``tractor``
 uses TCP and msgpack_.
@@ -623,7 +631,7 @@ The context notion comes from the context_ in nanomsg_.
 
 
 Running actors standalone
--------------------------
+*************************
 You don't have to spawn any actors using ``open_nursery()`` if you just
 want to run a single actor that connects to an existing cluster.
 All the comms and arbiter registration stuff still works. This can
@@ -637,7 +645,7 @@ need to hop into a debugger. You just need to pass the existing
 
 
 Enabling logging
-----------------
+****************
 Considering how complicated distributed software can become it helps to know
 what exactly it's doing (even at the lowest levels). Luckily ``tractor`` has
 tons of logging throughout the core. ``tractor`` isn't opinionated on

--- a/README.rst
+++ b/README.rst
@@ -193,7 +193,7 @@ What's going on?
   much like you'd expect from a future_.
 
 This ``run_in_actor()`` API should look very familiar to users of
-``asyncio``'s run_in_executor_ which uses a ``concurrent.futures`` Executor_.
+``asyncio``'s `run_in_executor()`_ which uses a ``concurrent.futures`` Executor_.
 
 Since you might also want to spawn long running *worker* or *daemon*
 actors, each actor's *lifetime* can be determined based on the spawn
@@ -258,7 +258,7 @@ to all others with ease over standard network protocols).
 .. _nursery: https://trio.readthedocs.io/en/latest/reference-core.html#nurseries-and-spawning
 .. _causal: https://vorpus.org/blog/some-thoughts-on-asynchronous-api-design-in-a-post-asyncawait-world/#causality
 .. _cancelled: https://trio.readthedocs.io/en/latest/reference-core.html#child-tasks-and-cancellation
-.. _run_in_executor: https://docs.python.org/3/library/asyncio-eventloop.html#executor
+.. _run_in_executor(): https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.run_in_executor
 .. _Executor: https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor
 
 

--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,7 @@ the hip new film we're shooting:
             donny = await n.run_in_actor(
                 'donny',
                 say_hello,
+                # arguments are always named
                 other_actor='gretchen',
             )
             gretchen = await n.run_in_actor(
@@ -162,7 +163,7 @@ and use the ``run_in_actor()`` method:
             """
             async with tractor.open_nursery() as n:
 
-                portal = await n.run_in_actor('frank', movie_theatre_question)
+                portal = await n.run_in_actor('teacher', cellar_door)
 
             # The ``async with`` will unblock here since the 'frank'
             # actor has completed its main task ``movie_theatre_question()``.

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ setup(
         'tractor',
         'tractor.testing',
     ],
-    install_requires=['msgpack', 'trio>0.8', 'async_generator', 'colorlog'],
+    install_requires=[
+        'msgpack', 'trio>0.8', 'async_generator', 'colorlog', 'wrapt'],
     tests_require=['pytest'],
     python_requires=">=3.6",
     keywords=[

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -7,7 +7,6 @@ import pytest
 import trio
 import tractor
 
-
 from conftest import tractor_test
 
 

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -1,0 +1,81 @@
+from functools import partial
+from itertools import cycle
+
+import pytest
+import trio
+import tractor
+from async_generator import aclosing
+from tractor.testing import tractor_test
+
+
+def is_even(i):
+    return i % 2 == 0
+
+
+@tractor.msg.pub
+async def pubber(get_topics):
+    for i in cycle(range(10)):
+        topics = get_topics()
+        yield {'even' if is_even(i) else 'odd': i}
+        await trio.sleep(0.1)
+
+
+async def subs(which):
+    if len(which) == 1:
+        if which[0] == 'even':
+            pred = is_even
+        else:
+            pred = lambda i: not is_even(i)
+    else:
+        pred = lambda i: isinstance(i, int)
+
+    async with tractor.find_actor('streamer') as portal:
+        agen = await portal.run(__name__, 'pubber', topics=which)
+        async with aclosing(agen) as agen:
+            async for pkt in agen:
+                for topic, value in pkt.items():
+                    assert pred(value)
+
+
+def test_pubsub_multi_actor_subs(
+    loglevel,
+    arb_addr,
+):
+    async def main():
+        async with tractor.open_nursery() as n:
+            # start the publisher as a daemon
+            master_portal = await n.start_actor(
+                'streamer',
+                rpc_module_paths=[__name__],
+            )
+
+            even_portal = await n.run_in_actor('evens', subs, which=['even'])
+            odd_portal = await n.run_in_actor('odds', subs, which=['odd'])
+
+            async with tractor.wait_for_actor('odds'):
+                # block until 2nd actor is initialized
+                pass
+
+            # TODO: how to make this work when the arbiter gets
+            # a portal to itself? Currently this causes a hang
+            # when the channel server is torn down due to a lingering
+            # loopback channel
+            #     with trio.move_on_after(1):
+            #         await subs(['even', 'odd'])
+
+            # XXX: this would cause infinite
+            # blocking due to actor never terminating loop
+            # await even_portal.result()
+
+            await trio.sleep(1)
+            await even_portal.cancel_actor()
+            await trio.sleep(1)
+            await odd_portal.cancel_actor()
+
+            await master_portal.cancel_actor()
+
+    tractor.run(
+        main,
+        arbiter_addr=arb_addr,
+        rpc_module_paths=[__name__],
+    )

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -1,3 +1,4 @@
+import time
 from functools import partial
 from itertools import cycle
 
@@ -14,13 +15,18 @@ def is_even(i):
 
 @tractor.msg.pub
 async def pubber(get_topics):
+    ss = tractor.current_actor().statespace
+
     for i in cycle(range(10)):
-        topics = get_topics()
+
+        # ensure topic subscriptions are as expected
+        ss['get_topics'] = get_topics
+
         yield {'even' if is_even(i) else 'odd': i}
         await trio.sleep(0.1)
 
 
-async def subs(which):
+async def subs(which, pub_actor_name):
     if len(which) == 1:
         if which[0] == 'even':
             pred = is_even
@@ -29,7 +35,7 @@ async def subs(which):
     else:
         pred = lambda i: isinstance(i, int)
 
-    async with tractor.find_actor('streamer') as portal:
+    async with tractor.find_actor(pub_actor_name) as portal:
         agen = await portal.run(__name__, 'pubber', topics=which)
         async with aclosing(agen) as agen:
             async for pkt in agen:
@@ -37,24 +43,59 @@ async def subs(which):
                     assert pred(value)
 
 
+@pytest.mark.parametrize(
+    'pub_actor',
+    ['streamer', 'arbiter']
+)
 def test_pubsub_multi_actor_subs(
     loglevel,
     arb_addr,
+    pub_actor,
 ):
+    """Try out the neato @pub decorator system.
+    """
     async def main():
-        async with tractor.open_nursery() as n:
-            # start the publisher as a daemon
-            master_portal = await n.start_actor(
-                'streamer',
-                rpc_module_paths=[__name__],
-            )
+        ss = tractor.current_actor().statespace
 
-            even_portal = await n.run_in_actor('evens', subs, which=['even'])
-            odd_portal = await n.run_in_actor('odds', subs, which=['odd'])
+        async with tractor.open_nursery() as n:
+
+            name = 'arbiter'
+
+            if pub_actor is 'streamer':
+                # start the publisher as a daemon
+                master_portal = await n.start_actor(
+                    'streamer',
+                    rpc_module_paths=[__name__],
+                )
+
+            even_portal = await n.run_in_actor(
+                'evens', subs, which=['even'], pub_actor_name=name)
+            odd_portal = await n.run_in_actor(
+                'odds', subs, which=['odd'], pub_actor_name=name)
+
+            async with tractor.wait_for_actor('evens'):
+                # block until 2nd actor is initialized
+                pass
+
+            if pub_actor is 'arbiter':
+                # wait for publisher task to be spawned in a local RPC task
+                while not ss.get('get_topics'):
+                    await trio.sleep(0.1)
+
+                get_topics = ss.get('get_topics')
+
+                assert 'even' in get_topics()
 
             async with tractor.wait_for_actor('odds'):
                 # block until 2nd actor is initialized
                 pass
+
+            if pub_actor is 'arbiter':
+                start = time.time()
+                while 'odd' not in get_topics():
+                    await trio.sleep(0.1)
+                    if time.time() - start > 1:
+                        pytest.fail("odds subscription never arrived?")
 
             # TODO: how to make this work when the arbiter gets
             # a portal to itself? Currently this causes a hang
@@ -67,12 +108,23 @@ def test_pubsub_multi_actor_subs(
             # blocking due to actor never terminating loop
             # await even_portal.result()
 
-            await trio.sleep(1)
+            await trio.sleep(0.5)
             await even_portal.cancel_actor()
-            await trio.sleep(1)
-            await odd_portal.cancel_actor()
+            await trio.sleep(0.5)
 
-            await master_portal.cancel_actor()
+            if pub_actor is 'arbiter':
+                assert 'even' not in get_topics()
+
+            await odd_portal.cancel_actor()
+            await trio.sleep(1)
+
+            if pub_actor is 'arbiter':
+                while get_topics():
+                    await trio.sleep(0.1)
+                    if time.time() - start > 1:
+                        pytest.fail("odds subscription never dropped?")
+            else:
+                await master_portal.cancel_actor()
 
     tractor.run(
         main,

--- a/tractor/__init__.py
+++ b/tractor/__init__.py
@@ -18,6 +18,7 @@ from ._actor import (
 from ._trionics import open_nursery
 from ._state import current_actor
 from ._exceptions import RemoteActorError, ModuleNotExposed
+from . import msg
 
 
 __all__ = [
@@ -30,6 +31,7 @@ __all__ = [
     'MultiError',
     'RemoteActorError',
     'ModuleNotExposed',
+    'msg'
 ]
 
 

--- a/tractor/__init__.py
+++ b/tractor/__init__.py
@@ -11,7 +11,7 @@ import trio  # type: ignore
 from trio import MultiError
 
 from .log import get_console_log, get_logger, get_loglevel
-from ._ipc import _connect_chan, Channel
+from ._ipc import _connect_chan, Channel, Context
 from ._actor import (
     Actor, _start_actor, Arbiter, get_arbiter, find_actor, wait_for_actor
 )

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -140,18 +140,14 @@ async def _invoke(
             task_status.started(err)
     finally:
         # RPC task bookeeping
-        tasks = actor._rpc_tasks.get(chan, None)
-        if tasks:
-            try:
-                scope, func = tasks.pop(cid)
-            except ValueError:
-                # If we're cancelled before the task returns then the
-                # cancel scope will not have been inserted yet
-                log.warn(
-                    f"Task {func} was likely cancelled before it was started")
-
-        if not tasks:
-            actor._rpc_tasks.pop(chan, None)
+        try:
+            scope, func, is_complete = actor._rpc_tasks.pop((chan, cid))
+            is_complete.set()
+        except KeyError:
+            # If we're cancelled before the task returns then the
+            # cancel scope will not have been inserted yet
+            log.warn(
+                f"Task {func} was likely cancelled before it was started")
 
         if not actor._rpc_tasks:
             log.info(f"All RPC tasks have completed")
@@ -197,9 +193,10 @@ class Actor:
 
         self._no_more_rpc_tasks = trio.Event()
         self._no_more_rpc_tasks.set()
+        # (chan, cid) -> (cancel_scope, func)
         self._rpc_tasks: Dict[
-            Channel,
-            Dict[str, Tuple[trio._core._run.CancelScope, typing.Callable]]
+            Tuple[Channel, str],
+            Tuple[trio._core._run.CancelScope, typing.Callable, trio.Event]
         ] = {}
         # map {uids -> {callids -> waiter queues}}
         self._actors2calls: Dict[Tuple[str, str], Dict[str, trio.Queue]] = {}
@@ -268,7 +265,7 @@ class Actor:
             log.warning(
                 f"already have channel(s) for {uid}:{chans}?"
             )
-        log.debug(f"Registered {chan} for {uid}")
+        log.trace(f"Registered {chan} for {uid}")
         # append new channel
         self._peers[uid].append(chan)
 
@@ -295,8 +292,9 @@ class Actor:
             if chan.connected():
                 log.debug(f"Disconnecting channel {chan}")
                 try:
+                    # send our msg loop terminate sentinel
                     await chan.send(None)
-                    await chan.aclose()
+                    # await chan.aclose()
                 except trio.BrokenResourceError:
                     log.exception(
                         f"Channel for {chan.uid} was already zonked..")
@@ -334,7 +332,10 @@ class Actor:
         return cid, q
 
     async def _process_messages(
-        self, chan: Channel, treat_as_gen: bool = False
+        self, chan: Channel,
+        treat_as_gen: bool = False,
+        shield: bool = False,
+        task_status=trio.TASK_STATUS_IGNORED,
     ) -> None:
         """Process messages for the channel async-RPC style.
 
@@ -342,91 +343,90 @@ class Actor:
         """
         # TODO: once https://github.com/python-trio/trio/issues/467 gets
         # worked out we'll likely want to use that!
+        msg = None
         log.debug(f"Entering msg loop for {chan} from {chan.uid}")
         try:
-            async for msg in chan:
-                if msg is None:  # terminate sentinel
-                    log.debug(
-                        f"Cancelling all tasks for {chan} from {chan.uid}")
-                    for cid, (scope, func) in self._rpc_tasks.pop(
-                        chan, {}
-                    ).items():
-                        scope.cancel()
-                    log.debug(
-                            f"Msg loop signalled to terminate for"
-                            f" {chan} from {chan.uid}")
-                    break
-                log.debug(f"Received msg {msg} from {chan.uid}")
-                cid = msg.get('cid')
-                if cid:
-                    cancel = msg.get('cancel')
-                    if cancel:
-                        # right now this is only implicitly used by
-                        # async generator IPC
-                        scope, func = self._rpc_tasks[chan][cid]
+            # internal scope allows for keeping this message
+            # loop running despite the current task having been
+            # cancelled (eg. `open_portal()` may call this method from
+            # a locally spawned task)
+            with trio.open_cancel_scope(shield=shield) as cs:
+                task_status.started(cs)
+                async for msg in chan:
+                    if msg is None:  # loop terminate sentinel
                         log.debug(
-                            f"Received cancel request for task {cid}"
-                            f" from {chan.uid}")
-                        scope.cancel()
-                    else:
+                            f"Cancelling all tasks for {chan} from {chan.uid}")
+                        for (channel, cid) in self._rpc_tasks:
+                            if channel is chan:
+                                self.cancel_task(cid, Context(channel, cid))
+                        log.debug(
+                                f"Msg loop signalled to terminate for"
+                                f" {chan} from {chan.uid}")
+                        break
+
+                    log.debug(f"Received msg {msg} from {chan.uid}")
+                    cid = msg.get('cid')
+                    if cid:
                         # deliver response to local caller/waiter
                         await self._push_result(chan.uid, cid, msg)
                         log.debug(
                             f"Waiting on next msg for {chan} from {chan.uid}")
-                    continue
-
-                # process command request
-                try:
-                    ns, funcname, kwargs, actorid, cid = msg['cmd']
-                except KeyError:
-                    # This is the non-rpc error case, that is, an
-                    # error **not** raised inside a call to ``_invoke()``
-                    # (i.e. no cid was provided in the msg - see above).
-                    # Push this error to all local channel consumers
-                    # (normally portals) by marking the channel as errored
-                    assert chan.uid
-                    exc = unpack_error(msg, chan=chan)
-                    chan._exc = exc
-                    raise exc
-
-                log.debug(
-                    f"Processing request from {actorid}\n"
-                    f"{ns}.{funcname}({kwargs})")
-                if ns == 'self':
-                    func = getattr(self, funcname)
-                else:
-                    # complain to client about restricted modules
-                    try:
-                        func = self._get_rpc_func(ns, funcname)
-                    except (ModuleNotExposed, AttributeError) as err:
-                        err_msg = pack_error(err)
-                        err_msg['cid'] = cid
-                        await chan.send(err_msg)
                         continue
 
-                # spin up a task for the requested function
-                log.debug(f"Spawning task for {func}")
-                cs = await self._root_nursery.start(
-                    _invoke, self, cid, chan, func, kwargs,
-                    name=funcname
-                )
-                # never allow cancelling cancel requests (results in
-                # deadlock and other weird behaviour)
-                if func != self.cancel:
-                    if isinstance(cs, Exception):
-                        log.warn(f"Task for RPC func {func} failed with {cs}")
+                    # process command request
+                    try:
+                        ns, funcname, kwargs, actorid, cid = msg['cmd']
+                    except KeyError:
+                        # This is the non-rpc error case, that is, an
+                        # error **not** raised inside a call to ``_invoke()``
+                        # (i.e. no cid was provided in the msg - see above).
+                        # Push this error to all local channel consumers
+                        # (normally portals) by marking the channel as errored
+                        assert chan.uid
+                        exc = unpack_error(msg, chan=chan)
+                        chan._exc = exc
+                        raise exc
+
+                    log.debug(
+                        f"Processing request from {actorid}\n"
+                        f"{ns}.{funcname}({kwargs})")
+                    if ns == 'self':
+                        func = getattr(self, funcname)
                     else:
-                        # mark that we have ongoing rpc tasks
-                        self._no_more_rpc_tasks.clear()
-                        log.info(f"RPC func is {func}")
-                        # store cancel scope such that the rpc task can be
-                        # cancelled gracefully if requested
-                        self._rpc_tasks.setdefault(chan, {})[cid] = (cs, func)
-                log.debug(
-                    f"Waiting on next msg for {chan} from {chan.uid}")
-            else:
-                # channel disconnect
-                log.debug(f"{chan} from {chan.uid} disconnected")
+                        # complain to client about restricted modules
+                        try:
+                            func = self._get_rpc_func(ns, funcname)
+                        except (ModuleNotExposed, AttributeError) as err:
+                            err_msg = pack_error(err)
+                            err_msg['cid'] = cid
+                            await chan.send(err_msg)
+                            continue
+
+                    # spin up a task for the requested function
+                    log.debug(f"Spawning task for {func}")
+                    cs = await self._root_nursery.start(
+                        _invoke, self, cid, chan, func, kwargs,
+                        name=funcname
+                    )
+                    # never allow cancelling cancel requests (results in
+                    # deadlock and other weird behaviour)
+                    if func != self.cancel:
+                        if isinstance(cs, Exception):
+                            log.warn(f"Task for RPC func {func} failed with"
+                                     f"{cs}")
+                        else:
+                            # mark that we have ongoing rpc tasks
+                            self._no_more_rpc_tasks.clear()
+                            log.info(f"RPC func is {func}")
+                            # store cancel scope such that the rpc task can be
+                            # cancelled gracefully if requested
+                            self._rpc_tasks[(chan, cid)] = (
+                                cs, func, trio.Event())
+                    log.debug(
+                        f"Waiting on next msg for {chan} from {chan.uid}")
+                else:
+                    # channel disconnect
+                    log.debug(f"{chan} from {chan.uid} disconnected")
 
         except trio.ClosedResourceError:
             log.error(f"{chan} form {chan.uid} broke")
@@ -439,8 +439,14 @@ class Actor:
             raise
             # if this is the `MainProcess` we expect the error broadcasting
             # above to trigger an error at consuming portal "checkpoints"
+        except trio.Cancelled:
+            # debugging only
+            log.debug("Msg loop was cancelled")
+            raise
         finally:
-            log.debug(f"Exiting msg loop for {chan} from {chan.uid}")
+            log.debug(
+                f"Exiting msg loop for {chan} from {chan.uid} "
+                f"with last msg:\n{msg}")
 
     def _fork_main(
         self,
@@ -541,8 +547,7 @@ class Actor:
             if self._parent_chan:
                 try:
                     # internal error so ship to parent without cid
-                    await self._parent_chan.send(
-                        pack_error(err))
+                    await self._parent_chan.send(pack_error(err))
                 except trio.ClosedResourceError:
                     log.error(
                         f"Failed to ship error to parent "
@@ -627,21 +632,47 @@ class Actor:
         self.cancel_server()
         self._root_nursery.cancel_scope.cancel()
 
+    async def cancel_task(self, cid, ctx):
+        """Cancel a local task.
+
+        Note this method will be treated as a streaming funciton
+        by remote actor-callers due to the declaration of ``ctx``
+        in the signature (for now).
+        """
+        # right now this is only implicitly called by
+        # streaming IPC but it should be called
+        # to cancel any remotely spawned task
+        chan = ctx.chan
+        # the ``dict.get()`` ensures the requested task to be cancelled
+        # was indeed spawned by a request from this channel
+        scope, func, is_complete = self._rpc_tasks[(ctx.chan, cid)]
+        log.debug(
+            f"Cancelling task:\ncid: {cid}\nfunc: {func}\n"
+            f"peer: {chan.uid}\n")
+
+        # if func is self.cancel_task:
+        #     return
+
+        scope.cancel()
+        # wait for _invoke to mark the task complete
+        await is_complete.wait()
+        log.debug(
+            f"Sucessfully cancelled task:\ncid: {cid}\nfunc: {func}\n"
+            f"peer: {chan.uid}\n")
+
     async def cancel_rpc_tasks(self) -> None:
         """Cancel all existing RPC responder tasks using the cancel scope
         registered for each.
         """
         tasks = self._rpc_tasks
-        log.info(f"Cancelling all {len(tasks)} rpc tasks:\n{tasks}")
-        for chan, cids2scopes in tasks.items():
-            log.debug(f"Cancelling all tasks for {chan.uid}")
-            for cid, (scope, func) in cids2scopes.items():
-                log.debug(f"Cancelling task for {func}")
-                scope.cancel()
-        if tasks:
-            log.info(
-                f"Waiting for remaining rpc tasks to complete {tasks}")
-            await self._no_more_rpc_tasks.wait()
+        log.info(f"Cancelling all {len(tasks)} rpc tasks:\n{tasks} ")
+        for (chan, cid) in tasks.copy():
+            # TODO: this should really done in a nursery batch
+            await self.cancel_task(cid, Context(chan, cid))
+        # if tasks:
+        log.info(
+            f"Waiting for remaining rpc tasks to complete {tasks}")
+        await self._no_more_rpc_tasks.wait()
 
     def cancel_server(self) -> None:
         """Cancel the internal channel server nursery thereby
@@ -810,7 +841,9 @@ async def find_actor(
         sockaddr = await arb_portal.run('self', 'find_actor', name=name)
         # TODO: return portals to all available actors - for now just
         # the last one that registered
-        if sockaddr:
+        if name == 'arbiter' and actor.is_arbiter:
+            raise RuntimeError("The current actor is the arbiter")
+        elif sockaddr:
             async with _connect_chan(*sockaddr) as chan:
                 async with open_portal(chan) as portal:
                     yield portal

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -453,6 +453,8 @@ class Actor:
         self._forkserver_info = forkserver_info
         from ._trionics import ctx
         if self.loglevel is not None:
+            log.info(
+                f"Setting loglevel for {self.uid} to {self.loglevel}")
             get_console_log(self.loglevel)
         log.info(
             f"Started new {ctx.current_process()} for {self.uid}")

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -265,7 +265,7 @@ class Actor:
             log.warning(
                 f"already have channel(s) for {uid}:{chans}?"
             )
-        log.trace(f"Registered {chan} for {uid}")
+        log.trace(f"Registered {chan} for {uid}")  # type: ignore
         # append new channel
         self._peers[uid].append(chan)
 
@@ -650,8 +650,10 @@ class Actor:
             f"Cancelling task:\ncid: {cid}\nfunc: {func}\n"
             f"peer: {chan.uid}\n")
 
-        # if func is self.cancel_task:
-        #     return
+        # don't allow cancelling this function mid-execution
+        # (is this necessary?)
+        if func is self.cancel_task:
+            return
 
         scope.cancel()
         # wait for _invoke to mark the task complete

--- a/tractor/_exceptions.py
+++ b/tractor/_exceptions.py
@@ -39,7 +39,7 @@ class NoResult(RuntimeError):
     "No final result is expected for this actor"
 
 
-class ModuleNotExposed(RuntimeError):
+class ModuleNotExposed(ModuleNotFoundError):
     "The requested module is not exposed for RPC"
 
 

--- a/tractor/_exceptions.py
+++ b/tractor/_exceptions.py
@@ -55,12 +55,12 @@ def pack_error(exc):
     }
 
 
-def unpack_error(msg, chan=None):
+def unpack_error(msg, chan=None, err_type=RemoteActorError):
     """Unpack an 'error' message from the wire
     into a local ``RemoteActorError``.
     """
     tb_str = msg['error'].get('tb_str', '')
-    return RemoteActorError(
+    return err_type(
         f"{chan.uid}\n" + tb_str,
         **msg['error'],
     )

--- a/tractor/_ipc.py
+++ b/tractor/_ipc.py
@@ -1,6 +1,7 @@
 """
 Inter-process comms abstractions
 """
+from dataclasses import dataclass
 import typing
 from typing import Any, Tuple, Optional
 
@@ -205,6 +206,7 @@ class Channel:
         return self.squeue.connected() if self.squeue else False
 
 
+@dataclass(frozen=True)
 class Context:
     """An IAC (inter-actor communication) context.
 
@@ -212,13 +214,12 @@ class Context:
     actors. A unique context is created on the receiving end for every request
     to a remote actor.
     """
-    def __init__(
-        self,
-        channel: Channel,
-        command_id: str,
-    ) -> None:
-        self.chan: Channel = channel
-        self.cid: str = command_id
+    chan: Channel
+    cid: str
+
+    # TODO: we should probably attach the actor-task
+    # cancel scope here now that trio is exposing it
+    # as a public object
 
     async def send_yield(self, data: Any) -> None:
         await self.chan.send({'yield': data, 'cid': self.cid})

--- a/tractor/_ipc.py
+++ b/tractor/_ipc.py
@@ -216,14 +216,14 @@ class Context:
         self,
         channel: Channel,
         command_id: str,
-    ):
+    ) -> None:
         self.chan: Channel = channel
         self.cid: str = command_id
 
-    async def send_yield(self, data):
+    async def send_yield(self, data: Any) -> None:
         await self.chan.send({'yield': data, 'cid': self.cid})
 
-    async def send_stop(self):
+    async def send_stop(self) -> None:
         await self.chan.send({'stop': True, 'cid': self.cid})
 
 

--- a/tractor/_ipc.py
+++ b/tractor/_ipc.py
@@ -205,6 +205,28 @@ class Channel:
         return self.squeue.connected() if self.squeue else False
 
 
+class Context:
+    """An IAC (inter-actor communication) context.
+
+    Allows maintaining task or protocol specific state between communicating
+    actors. A unique context is created on the receiving end for every request
+    to a remote actor.
+    """
+    def __init__(
+        self,
+        channel: Channel,
+        command_id: str,
+    ):
+        self.chan: Channel = channel
+        self.cid: str = command_id
+
+    async def send_yield(self, data):
+        await self.chan.send({'yield': data, 'cid': self.cid})
+
+    async def send_stop(self):
+        await self.chan.send({'stop': True, 'cid': self.cid})
+
+
 @asynccontextmanager
 async def _connect_chan(
     host: str, port: int

--- a/tractor/_trionics.py
+++ b/tractor/_trionics.py
@@ -317,7 +317,7 @@ class ActorNursery:
                 # the `else:` block here might not complete?
                 # For now, shield both.
                 with trio.open_cancel_scope(shield=True):
-                    if etype is trio.Cancelled:
+                    if etype in (trio.Cancelled, KeyboardInterrupt):
                         log.warning(
                             f"Nursery for {current_actor().uid} was "
                             f"cancelled with {etype}")

--- a/tractor/_trionics.py
+++ b/tractor/_trionics.py
@@ -114,7 +114,7 @@ class ActorNursery:
         name: str,
         fn: typing.Callable,
         bind_addr: Tuple[str, int] = ('127.0.0.1', 0),
-        rpc_module_paths: List[str] = None,
+        rpc_module_paths: List[str] = [],
         statespace: Dict[str, Any] = None,
         loglevel: str = None,  # set log level per subactor
         **kwargs,  # explicit args to ``fn``
@@ -129,7 +129,7 @@ class ActorNursery:
         mod_path = fn.__module__
         portal = await self.start_actor(
             name,
-            rpc_module_paths=[mod_path],
+            rpc_module_paths=[mod_path] + rpc_module_paths,
             bind_addr=bind_addr,
             statespace=statespace,
         )

--- a/tractor/msg.py
+++ b/tractor/msg.py
@@ -2,8 +2,9 @@
 Messaging pattern APIs and helpers.
 """
 import typing
-from typing import Dict, Any
+from typing import Dict, Any, Sequence
 from functools import partial
+from async_generator import aclosing
 
 import trio
 import wrapt
@@ -17,44 +18,46 @@ log = get_logger('messaging')
 
 
 async def fan_out_to_ctxs(
-    pub_gen: typing.Callable,  # it's an async gen ... gd mypy
+    pub_async_gen_func: typing.Callable,  # it's an async gen ... gd mypy
     topics2ctxs: Dict[str, set],
-    topic_key: str = 'key',
+    packetizer: typing.Callable = None,
 ) -> None:
     """Request and fan out quotes to each subscribed actor channel.
     """
     def get_topics():
         return tuple(topics2ctxs.keys())
 
-    async for published in pub_gen(
-        get_topics=get_topics,
-    ):
-        ctx_payloads: Dict[str, Any] = {}
-        for packet_key, data in published.items():
-            # grab each suscription topic using provided key for lookup
-            topic = data[topic_key]
-            # build a new dict packet for passing to multiple channels
-            packet = {packet_key: data}
-            for ctx in topics2ctxs.get(topic, set()):
-                ctx_payloads.setdefault(ctx, {}).update(packet),
+    agen = pub_async_gen_func(get_topics=get_topics)
+    async with aclosing(agen) as pub_gen:
+        async for published in pub_gen:
+            ctx_payloads: Dict[str, Any] = {}
+            for topic, data in published.items():
+                log.debug(f"publishing {topic, data}")
+                # build a new dict packet or invoke provided packetizer
+                if packetizer is None:
+                    packet = {topic: data}
+                else:
+                    packet = packetizer(topic, data)
+                for ctx in topics2ctxs.get(topic, set()):
+                    ctx_payloads.setdefault(ctx, {}).update(packet),
 
-        # deliver to each subscriber (fan out)
-        if ctx_payloads:
-            for ctx, payload in ctx_payloads.items():
-                try:
-                    await ctx.send_yield(payload)
-                except (
-                    # That's right, anything you can think of...
-                    trio.ClosedStreamError, ConnectionResetError,
-                    ConnectionRefusedError,
-                ):
-                    log.warn(f"{ctx.chan} went down?")
-                    for ctx_set in topics2ctxs.values():
-                        ctx_set.discard(ctx)
+            # deliver to each subscriber (fan out)
+            if ctx_payloads:
+                for ctx, payload in ctx_payloads.items():
+                    try:
+                        await ctx.send_yield(payload)
+                    except (
+                        # That's right, anything you can think of...
+                        trio.ClosedStreamError, ConnectionResetError,
+                        ConnectionRefusedError,
+                    ):
+                        log.warning(f"{ctx.chan} went down?")
+                        for ctx_set in topics2ctxs.values():
+                            ctx_set.discard(ctx)
 
-        if not any(topics2ctxs.values()):
-            log.warn(f"No subscribers left for {pub_gen.__name__}")
-            break
+            if not get_topics():
+                log.warning(f"No subscribers left for {pub_gen}")
+                break
 
 
 def modify_subs(topics2ctxs, topics, ctx):
@@ -62,7 +65,7 @@ def modify_subs(topics2ctxs, topics, ctx):
 
     Effectively a symbol subscription api.
     """
-    log.info(f"{ctx.chan} changed subscription to {topics}")
+    log.info(f"{ctx.chan.uid} changed subscription to {topics}")
 
     # update map from each symbol to requesting client's chan
     for ticker in topics:
@@ -82,46 +85,127 @@ def modify_subs(topics2ctxs, topics, ctx):
             topics2ctxs.pop(ticker)
 
 
-def pub(*, tasks=()):
+def pub(
+    wrapped: typing.Callable = None,
+    *,
+    tasks: Sequence[str] = set(),
+):
     """Publisher async generator decorator.
 
-    A publisher can be called many times from different actor's
-    remote tasks but will only spawn one internal task to deliver
-    values to all callers. Values yielded from the decorated
-    async generator are sent back to each calling task, filtered by
-    topic on the producer (server) side.
+    A publisher can be called multiple times from different actors
+    but will only spawn a finite set of internal tasks to stream values
+    to each caller. The ``tasks` argument to the decorator (``Set[str]``)
+    specifies the names of the mutex set of publisher tasks.
+    When the publisher function is called, an argument ``task_name`` must be
+    passed to specify which task (of the set named in ``tasks``) should be
+    used. This allows for using the same publisher with different input
+    (arguments) without allowing more concurrent tasks then necessary.
 
-    Must be called with a topic as the first arg.
+    Values yielded from the decorated async generator
+    must be ``Dict[str, Dict[str, Any]]`` where the fist level key is the
+    topic string an determines which subscription the packet will be delivered
+    to and the value is a packet ``Dict[str, Any]`` by default of the form:
+
+    .. ::python
+
+        {topic: value}
+
+    The caller can instead opt to pass a ``packetizer`` callback who's return
+    value will be delivered as the published response.
+
+    The decorated function must *accept* an argument :func:`get_topics` which
+    dynamically returns the tuple of current subscriber topics:
+
+    .. code:: python
+
+        from tractor.msg import pub
+
+        @pub(tasks={'source_1', 'source_2'})
+        async def pub_service(get_topics):
+            data = await web_request(endpoints=get_topics())
+            for item in data:
+                yield data['key'], data
+
+
+    The publisher must be called passing in the following arguments:
+    - ``topics: Sequence[str]`` the topic sequence or "subscriptions"
+    - ``task_name: str`` the task to use (if ``tasks`` was passed)
+    - ``ctx: Context`` the tractor context (only needed if calling the
+      pub func without a nursery, otherwise this is provided implicitly)
+    - packetizer: ``Callable[[str, Any], Any]`` a callback who receives
+      the topic and value from the publisher function each ``yield`` such that
+      whatever is returned is sent as the published value to subscribers of
+      that topic.  By default this is a dict ``{topic: value}``.
+
+    As an example, to make a subscriber call the above function:
+
+    .. code:: python
+
+        from functools import partial
+        import tractor
+
+        async with tractor.open_nursery() as n:
+            portal = n.run_in_actor(
+                'publisher',  # actor name
+                partial(      # func to execute in it
+                    pub_service,
+                    topics=('clicks', 'users'),
+                    task_name='source1',
+                )
+            )
+            async for value in portal.result():
+                print(f"Subscriber received {value}")
+
+
+    Here, you don't need to provide the ``ctx`` argument since the remote actor
+    provides it automatically to the spawned task. If you were to call
+    ``pub_service()`` directly from a wrapping function you would need to
+    provide this explicitly.
+
+    Remember you only need this if you need *a finite set of tasks* running in
+    a single actor to stream data to an arbitrary number of subscribers. If you
+    are ok to have a new task running for every call to ``pub_service()`` then
+    probably don't need this.
     """
-    task2lock = {}
+    # handle the decorator not called with () case
+    if wrapped is None:
+        return partial(pub, tasks=tasks)
+
+    task2lock = {None: trio.StrictFIFOLock()}
     for name in tasks:
         task2lock[name] = trio.StrictFIFOLock()
 
-    @wrapt.decorator
+    async def takes_ctx(get_topics, ctx=None):
+        pass
+
+    @wrapt.decorator(adapter=takes_ctx)
     async def wrapper(agen, instance, args, kwargs):
+        task_name = None
         if tasks:
-            task_key = kwargs.pop('task_key')
-            if not task_key:
+            try:
+                task_name = kwargs.pop('task_name')
+            except KeyError:
                 raise TypeError(
-                    f"{agen} must be called with a `task_key` named argument "
+                    f"{agen} must be called with a `task_name` named argument "
                     f"with a falue from {tasks}")
 
         # pop required kwargs used internally
         ctx = kwargs.pop('ctx')
         topics = kwargs.pop('topics')
-        topic_key = kwargs.pop('topic_key')
+        packetizer = kwargs.pop('packetizer', None)
 
-        lock = task2lock[task_key]
         ss = current_actor().statespace
+        lockmap = ss.setdefault('_pubtask2lock', task2lock)
+        lock = lockmap[task_name]
+
         all_subs = ss.setdefault('_subs', {})
-        topics2ctxs = all_subs.setdefault(task_key, {})
+        topics2ctxs = all_subs.setdefault(task_name, {})
 
         try:
             modify_subs(topics2ctxs, topics, ctx)
             # block and let existing feed task deliver
             # stream data until it is cancelled in which case
-            # we'll take over and spawn it again
-            # update map from each symbol to requesting client's chan
+            # the next waiting task will take over and spawn it again
             async with lock:
                 # no data feeder task yet; so start one
                 respawn = True
@@ -132,11 +216,11 @@ def pub(*, tasks=()):
                         # unblocks when no more symbols subscriptions exist
                         # and the streamer task terminates
                         await fan_out_to_ctxs(
-                            pub_gen=partial(agen, *args, **kwargs),
+                            pub_async_gen_func=partial(agen, *args, **kwargs),
                             topics2ctxs=topics2ctxs,
-                            topic_key=topic_key,
+                            packetizer=packetizer,
                         )
-                        log.info(f"Terminating stream task for {task_key}"
+                        log.info(f"Terminating stream task {task_name or ''}"
                                  f" for {agen.__name__}")
                     except trio.BrokenResourceError:
                         log.exception("Respawning failed data feed task")
@@ -148,6 +232,6 @@ def pub(*, tasks=()):
             # if there are truly no more subscriptions with this broker
             # drop from broker subs dict
             if not any(topics2ctxs.values()):
-                log.info(f"No more subscriptions for publisher {task_key}")
+                log.info(f"No more subscriptions for publisher {task_name}")
 
-    return wrapper
+    return wrapper(wrapped)

--- a/tractor/msg.py
+++ b/tractor/msg.py
@@ -2,7 +2,7 @@
 Messaging pattern APIs and helpers.
 """
 import typing
-from typing import Dict, Any, Sequence
+from typing import Dict, Any, Set, Union
 from functools import partial
 from async_generator import aclosing
 
@@ -88,7 +88,7 @@ def modify_subs(topics2ctxs, topics, ctx):
 def pub(
     wrapped: typing.Callable = None,
     *,
-    tasks: Sequence[str] = set(),
+    tasks: Set[str] = set(),
 ):
     """Publisher async generator decorator.
 
@@ -128,7 +128,7 @@ def pub(
 
 
     The publisher must be called passing in the following arguments:
-    - ``topics: Sequence[str]`` the topic sequence or "subscriptions"
+    - ``topics: Set[str]`` the topic sequence or "subscriptions"
     - ``task_name: str`` the task to use (if ``tasks`` was passed)
     - ``ctx: Context`` the tractor context (only needed if calling the
       pub func without a nursery, otherwise this is provided implicitly)
@@ -171,7 +171,8 @@ def pub(
     if wrapped is None:
         return partial(pub, tasks=tasks)
 
-    task2lock = {None: trio.StrictFIFOLock()}
+    task2lock: Dict[Union[str, None], trio.StrictFIFOLock] = {
+        None: trio.StrictFIFOLock()}
     for name in tasks:
         task2lock[name] = trio.StrictFIFOLock()
 

--- a/tractor/msg.py
+++ b/tractor/msg.py
@@ -2,13 +2,12 @@
 Messaging pattern APIs and helpers.
 """
 import typing
-from typing import Dict
+from typing import Dict, Any
 from functools import partial
 
 import trio
 import wrapt
 
-from ._ipc import Context
 from .log import get_logger
 from . import current_actor
 
@@ -18,8 +17,8 @@ log = get_logger('messaging')
 
 
 async def fan_out_to_ctxs(
-    pub_gen: typing.AsyncGenerator,
-    topics2ctxs: Dict[str, Context],
+    pub_gen: typing.Callable,  # it's an async gen ... gd mypy
+    topics2ctxs: Dict[str, set],
     topic_key: str = 'key',
 ) -> None:
     """Request and fan out quotes to each subscribed actor channel.
@@ -30,7 +29,7 @@ async def fan_out_to_ctxs(
     async for published in pub_gen(
         get_topics=get_topics,
     ):
-        ctx_payloads = {}
+        ctx_payloads: Dict[str, Any] = {}
         for packet_key, data in published.items():
             # grab each suscription topic using provided key for lookup
             topic = data[topic_key]

--- a/tractor/msg.py
+++ b/tractor/msg.py
@@ -68,21 +68,21 @@ def modify_subs(topics2ctxs, topics, ctx):
     log.info(f"{ctx.chan.uid} changed subscription to {topics}")
 
     # update map from each symbol to requesting client's chan
-    for ticker in topics:
-        topics2ctxs.setdefault(ticker, set()).add(ctx)
+    for topic in topics:
+        topics2ctxs.setdefault(topic, set()).add(ctx)
 
     # remove any existing symbol subscriptions if symbol is not
     # found in ``symbols``
     # TODO: this can likely be factored out into the pub-sub api
-    for ticker in filter(
+    for topic in filter(
         lambda topic: topic not in topics, topics2ctxs.copy()
     ):
-        ctx_set = topics2ctxs.get(ticker)
+        ctx_set = topics2ctxs.get(topic)
         ctx_set.discard(ctx)
 
         if not ctx_set:
             # pop empty sets which will trigger bg quoter task termination
-            topics2ctxs.pop(ticker)
+            topics2ctxs.pop(topic)
 
 
 def pub(

--- a/tractor/msg.py
+++ b/tractor/msg.py
@@ -1,0 +1,154 @@
+"""
+Messaging pattern APIs and helpers.
+"""
+import typing
+from typing import Dict
+from functools import partial
+
+import trio
+import wrapt
+
+from ._ipc import Context
+from .log import get_logger
+from . import current_actor
+
+__all__ = ['pub']
+
+log = get_logger('messaging')
+
+
+async def fan_out_to_ctxs(
+    pub_gen: typing.AsyncGenerator,
+    topics2ctxs: Dict[str, Context],
+    topic_key: str = 'key',
+) -> None:
+    """Request and fan out quotes to each subscribed actor channel.
+    """
+    def get_topics():
+        return tuple(topics2ctxs.keys())
+
+    async for published in pub_gen(
+        get_topics=get_topics,
+    ):
+        ctx_payloads = {}
+        for packet_key, data in published.items():
+            # grab each suscription topic using provided key for lookup
+            topic = data[topic_key]
+            # build a new dict packet for passing to multiple channels
+            packet = {packet_key: data}
+            for ctx in topics2ctxs.get(topic, set()):
+                ctx_payloads.setdefault(ctx, {}).update(packet),
+
+        # deliver to each subscriber (fan out)
+        if ctx_payloads:
+            for ctx, payload in ctx_payloads.items():
+                try:
+                    await ctx.send_yield(payload)
+                except (
+                    # That's right, anything you can think of...
+                    trio.ClosedStreamError, ConnectionResetError,
+                    ConnectionRefusedError,
+                ):
+                    log.warn(f"{ctx.chan} went down?")
+                    for ctx_set in topics2ctxs.values():
+                        ctx_set.discard(ctx)
+
+        if not any(topics2ctxs.values()):
+            log.warn(f"No subscribers left for {pub_gen.__name__}")
+            break
+
+
+def modify_subs(topics2ctxs, topics, ctx):
+    """Absolute symbol subscription list for each quote stream.
+
+    Effectively a symbol subscription api.
+    """
+    log.info(f"{ctx.chan} changed subscription to {topics}")
+
+    # update map from each symbol to requesting client's chan
+    for ticker in topics:
+        topics2ctxs.setdefault(ticker, set()).add(ctx)
+
+    # remove any existing symbol subscriptions if symbol is not
+    # found in ``symbols``
+    # TODO: this can likely be factored out into the pub-sub api
+    for ticker in filter(
+        lambda topic: topic not in topics, topics2ctxs.copy()
+    ):
+        ctx_set = topics2ctxs.get(ticker)
+        ctx_set.discard(ctx)
+
+        if not ctx_set:
+            # pop empty sets which will trigger bg quoter task termination
+            topics2ctxs.pop(ticker)
+
+
+def pub(*, tasks=()):
+    """Publisher async generator decorator.
+
+    A publisher can be called many times from different actor's
+    remote tasks but will only spawn one internal task to deliver
+    values to all callers. Values yielded from the decorated
+    async generator are sent back to each calling task, filtered by
+    topic on the producer (server) side.
+
+    Must be called with a topic as the first arg.
+    """
+    task2lock = {}
+    for name in tasks:
+        task2lock[name] = trio.StrictFIFOLock()
+
+    @wrapt.decorator
+    async def wrapper(agen, instance, args, kwargs):
+        if tasks:
+            task_key = kwargs.pop('task_key')
+            if not task_key:
+                raise TypeError(
+                    f"{agen} must be called with a `task_key` named argument "
+                    f"with a falue from {tasks}")
+
+        # pop required kwargs used internally
+        ctx = kwargs.pop('ctx')
+        topics = kwargs.pop('topics')
+        topic_key = kwargs.pop('topic_key')
+
+        lock = task2lock[task_key]
+        ss = current_actor().statespace
+        all_subs = ss.setdefault('_subs', {})
+        topics2ctxs = all_subs.setdefault(task_key, {})
+
+        try:
+            modify_subs(topics2ctxs, topics, ctx)
+            # block and let existing feed task deliver
+            # stream data until it is cancelled in which case
+            # we'll take over and spawn it again
+            # update map from each symbol to requesting client's chan
+            async with lock:
+                # no data feeder task yet; so start one
+                respawn = True
+                while respawn:
+                    respawn = False
+                    log.info(f"Spawning data feed task for {agen.__name__}")
+                    try:
+                        # unblocks when no more symbols subscriptions exist
+                        # and the streamer task terminates
+                        await fan_out_to_ctxs(
+                            pub_gen=partial(agen, *args, **kwargs),
+                            topics2ctxs=topics2ctxs,
+                            topic_key=topic_key,
+                        )
+                        log.info(f"Terminating stream task for {task_key}"
+                                 f" for {agen.__name__}")
+                    except trio.BrokenResourceError:
+                        log.exception("Respawning failed data feed task")
+                        respawn = True
+        finally:
+            # remove all subs for this context
+            modify_subs(topics2ctxs, (), ctx)
+
+            # if there are truly no more subscriptions with this broker
+            # drop from broker subs dict
+            if not any(topics2ctxs.values()):
+                log.info(f"No more subscriptions for publisher {task_key}")
+
+    return wrapper


### PR DESCRIPTION
An attempt at providing a very basic implementation of a *context* similar to [that offered in `nanomsg`](https://nanomsg.github.io/nng/man/v1.1.0/nng_ctx.5).

Also adding a `@tractor.msg.pub` publisher async gen decorator system.
This allows for building inter-actor on-demand streaming APIs.

Some other bug fixes regarding remote import-time error handling is also included.

ping @vodik @Konstantine00  