### PR TITLE
Use trio memory channels!

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     install_requires=[
         'msgpack', 'trio>0.8', 'async_generator', 'colorlog', 'wrapt'],
     tests_require=['pytest'],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     keywords=[
         "async", "concurrency", "actor model", "distributed",
         'trio', 'multiprocessing'

--- a/tests/test_multi_program.py
+++ b/tests/test_multi_program.py
@@ -70,7 +70,7 @@ async def test_cancel_remote_arbiter(daemon, arb_addr):
             pass
 
 
-async def test_register_duplicate_name(daemon, arb_addr):
+def test_register_duplicate_name(daemon, arb_addr):
 
     async def main():
         assert not tractor.current_actor().is_arbiter
@@ -85,4 +85,4 @@ async def test_register_duplicate_name(daemon, arb_addr):
 
     # run it manually since we want to start **after**
     # the other "daemon" program
-    tractor.run(main, arb_addr=arbiter_addr)
+    tractor.run(main, arbiter_addr=arb_addr)

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -4,7 +4,6 @@ from itertools import cycle
 import pytest
 import trio
 import tractor
-from async_generator import aclosing
 from tractor.testing import tractor_test
 
 
@@ -30,10 +29,10 @@ def is_even(i):
 
 
 @tractor.msg.pub
-async def pubber(get_topics):
+async def pubber(get_topics, seed=10):
     ss = tractor.current_actor().statespace
 
-    for i in cycle(range(10)):
+    for i in cycle(range(seed)):
 
         # ensure topic subscriptions are as expected
         ss['get_topics'] = get_topics
@@ -42,7 +41,11 @@ async def pubber(get_topics):
         await trio.sleep(0.1)
 
 
-async def subs(which, pub_actor_name):
+async def subs(
+    which, pub_actor_name, seed=10,
+    portal=None,
+    task_status=trio.TASK_STATUS_IGNORED,
+):
     if len(which) == 1:
         if which[0] == 'even':
             pred = is_even
@@ -54,11 +57,43 @@ async def subs(which, pub_actor_name):
             return isinstance(i, int)
 
     async with tractor.find_actor(pub_actor_name) as portal:
-        agen = await portal.run(__name__, 'pubber', topics=which)
-        async with aclosing(agen) as agen:
+        agen = await portal.run(
+            __name__, 'pubber',
+            topics=which,
+            seed=seed,
+        )
+        task_status.started(agen)
+        times = 10
+        count = 0
+        await agen.__anext__()
+        async for pkt in agen:
+            for topic, value in pkt.items():
+                assert pred(value)
+            count += 1
+            if count >= times:
+                break
+
+        await agen.aclose()
+
+        agen = await portal.run(
+            __name__, 'pubber',
+            topics=['odd'],
+            seed=seed,
+        )
+
+        await agen.__anext__()
+        count = 0
+        # async with aclosing(agen) as agen:
+        try:
             async for pkt in agen:
                 for topic, value in pkt.items():
-                    assert pred(value)
+                    pass
+                    # assert pred(value)
+                count += 1
+                if count >= times:
+                    break
+        finally:
+            await agen.aclose()
 
 
 @tractor.msg.pub(tasks=['one', 'two'])
@@ -101,7 +136,7 @@ async def test_required_args(callwith_expecterror):
     'pub_actor',
     ['streamer', 'arbiter']
 )
-def test_pubsub_multi_actor_subs(
+def test_multi_actor_subs_arbiter_pub(
     loglevel,
     arb_addr,
     pub_actor,
@@ -115,7 +150,7 @@ def test_pubsub_multi_actor_subs(
 
             name = 'arbiter'
 
-            if pub_actor is 'streamer':
+            if pub_actor == 'streamer':
                 # start the publisher as a daemon
                 master_portal = await n.start_actor(
                     'streamer',
@@ -131,7 +166,7 @@ def test_pubsub_multi_actor_subs(
                 # block until 2nd actor is initialized
                 pass
 
-            if pub_actor is 'arbiter':
+            if pub_actor == 'arbiter':
                 # wait for publisher task to be spawned in a local RPC task
                 while not ss.get('get_topics'):
                     await trio.sleep(0.1)
@@ -144,7 +179,7 @@ def test_pubsub_multi_actor_subs(
                 # block until 2nd actor is initialized
                 pass
 
-            if pub_actor is 'arbiter':
+            if pub_actor == 'arbiter':
                 start = time.time()
                 while 'odd' not in get_topics():
                     await trio.sleep(0.1)
@@ -166,19 +201,59 @@ def test_pubsub_multi_actor_subs(
             await even_portal.cancel_actor()
             await trio.sleep(0.5)
 
-            if pub_actor is 'arbiter':
+            if pub_actor == 'arbiter':
                 assert 'even' not in get_topics()
 
             await odd_portal.cancel_actor()
             await trio.sleep(1)
 
-            if pub_actor is 'arbiter':
+            if pub_actor == 'arbiter':
                 while get_topics():
                     await trio.sleep(0.1)
                     if time.time() - start > 1:
                         pytest.fail("odds subscription never dropped?")
             else:
                 await master_portal.cancel_actor()
+
+    tractor.run(
+        main,
+        arbiter_addr=arb_addr,
+        rpc_module_paths=[__name__],
+    )
+
+
+def test_single_subactor_pub_multitask_subs(
+    loglevel,
+    arb_addr,
+):
+    async def main():
+
+        async with tractor.open_nursery() as n:
+
+            portal = await n.start_actor(
+                'streamer',
+                rpc_module_paths=[__name__],
+            )
+            async with tractor.wait_for_actor('streamer'):
+                # block until 2nd actor is initialized
+                pass
+
+            async with trio.open_nursery() as tn:
+                agen = await tn.start(subs, ['even'], 'streamer')
+
+                await trio.sleep(0.1)
+                tn.start_soon(subs, ['even'], 'streamer')
+
+                # XXX this will trigger the python bug:
+                # https://bugs.python.org/issue32526
+                # await agen.aclose()
+
+                await trio.sleep(0.1)
+                tn.start_soon(subs, ['even'], 'streamer')
+                await trio.sleep(0.1)
+                tn.start_soon(subs, ['even'], 'streamer')
+
+            await portal.cancel_actor()
 
     tractor.run(
         main,

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -14,7 +14,7 @@ async def stream_seq(sequence):
         await trio.sleep(0.1)
 
     # block indefinitely waiting to be cancelled by ``aclose()`` call
-    with trio.open_cancel_scope() as cs:
+    with trio.CancelScope() as cs:
         await trio.sleep(float('inf'))
         assert 0
     assert cs.cancelled_caught

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -91,25 +91,25 @@ async def aggregate(seed):
 
             portals.append(portal)
 
-        q = trio.Queue(500)
+        send_chan, recv_chan = trio.open_memory_channel(500)
 
-        async def push_to_q(portal):
+        async def push_to_chan(portal):
             async for value in await portal.run(
                 __name__, 'stream_data', seed=seed
             ):
                 # leverage trio's built-in backpressure
-                await q.put(value)
+                await send_chan.send(value)
 
-            await q.put(None)
+            await send_chan.send(None)
             print(f"FINISHED ITERATING {portal.channel.uid}")
 
         # spawn 2 trio tasks to collect streams and push to a local queue
         async with trio.open_nursery() as n:
             for portal in portals:
-                n.start_soon(push_to_q, portal)
+                n.start_soon(push_to_chan, portal)
 
             unique_vals = set()
-            async for value in q:
+            async for value in recv_chan:
                 if value not in unique_vals:
                     unique_vals.add(value)
                     # yield upwards to the spawning parent actor

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -303,11 +303,12 @@ class Actor:
 
     async def _push_result(
         self,
-        actorid: Tuple[str, str],
+        chan: Channel,
         msg: Dict[str, Any],
     ) -> None:
         """Push an RPC result to the local consumer's queue.
         """
+        actorid = chan.uid
         assert actorid, f"`actorid` can't be {actorid}"
         cid = msg['cid']
         send_chan = self._cids2qs[(actorid, cid)]
@@ -390,10 +391,10 @@ class Actor:
                                 f" {chan} from {chan.uid}")
                         break
 
-                    log.trace(f"Received msg {msg} from {chan.uid}")
+                    log.trace(f"Received msg {msg} from {chan.uid}")  # type: ignore
                     if msg.get('cid'):
                         # deliver response to local caller/waiter
-                        await self._push_result(chan.uid, msg)
+                        await self._push_result(chan, msg)
                         log.debug(
                             f"Waiting on next msg for {chan} from {chan.uid}")
                         continue

--- a/tractor/_portal.py
+++ b/tractor/_portal.py
@@ -50,7 +50,7 @@ async def _do_handshake(
 
 class StreamReceiveChannel(trio.abc.ReceiveChannel):
     """A wrapper around a ``trio._channel.MemoryReceiveChannel`` with
-    special behaviour for signalling stream termination on across an
+    special behaviour for signalling stream termination across an
     inter-actor ``Channel``. This is the type returned to a local task
     which invoked a remote streaming function using `Portal.run()`.
 
@@ -126,7 +126,7 @@ class StreamReceiveChannel(trio.abc.ReceiveChannel):
                     "May have failed to cancel remote task "
                     f"{cid} for {self._portal.channel.uid}")
 
-        with trio.open_cancel_scope(shield=True):
+        with trio.CancelScope(shield=True):
             await self._rx_chan.aclose()
 
     def clone(self):

--- a/tractor/_state.py
+++ b/tractor/_state.py
@@ -1,6 +1,7 @@
 """
 Per process state
 """
+import multiprocessing as mp
 from typing import Optional
 
 
@@ -13,3 +14,9 @@ def current_actor() -> 'Actor':  # type: ignore
     if not _current_actor:
         raise RuntimeError("No actor instance has been defined yet?")
     return _current_actor
+
+
+def is_main_process():
+    """Bool determining if this actor is running in the top-most process.
+    """
+    return mp.current_process().name == 'MainProcess'

--- a/tractor/_trionics.py
+++ b/tractor/_trionics.py
@@ -353,7 +353,7 @@ async def open_nursery() -> typing.AsyncGenerator[ActorNursery, None]:
         raise RuntimeError("No actor instance has been defined yet?")
 
     # TODO: figure out supervisors from erlang
-    async with ActorNursery(current_actor()) as nursery:
+    async with ActorNursery(actor) as nursery:
         yield nursery
 
 

--- a/tractor/_trionics.py
+++ b/tractor/_trionics.py
@@ -185,7 +185,7 @@ class ActorNursery:
 
             Should only be called for actors spawned with `run_in_actor()`.
             """
-            with trio.open_cancel_scope() as cs:
+            with trio.CancelScope() as cs:
                 task_status.started(cs)
                 # if this call errors we store the exception for later
                 # in ``errors`` which will be reraised inside
@@ -316,7 +316,7 @@ class ActorNursery:
                 # a cancel signal shows up slightly after in which case
                 # the `else:` block here might not complete?
                 # For now, shield both.
-                with trio.open_cancel_scope(shield=True):
+                with trio.CancelScope(shield=True):
                     if etype in (trio.Cancelled, KeyboardInterrupt):
                         log.warning(
                             f"Nursery for {current_actor().uid} was "
@@ -355,9 +355,3 @@ async def open_nursery() -> typing.AsyncGenerator[ActorNursery, None]:
     # TODO: figure out supervisors from erlang
     async with ActorNursery(actor) as nursery:
         yield nursery
-
-
-def is_main_process():
-    """Bool determining if this actor is running in the top-most process.
-    """
-    return mp.current_process().name == 'MainProcess'

--- a/tractor/msg.py
+++ b/tractor/msg.py
@@ -43,6 +43,9 @@ async def fan_out_to_ctxs(
                 for ctx in topics2ctxs.get(topic, set()):
                     ctx_payloads.setdefault(ctx, {}).update(packet),
 
+            if not ctx_payloads:
+                log.debug(f"Unconsumed values:\n{published}")
+
             # deliver to each subscriber (fan out)
             if ctx_payloads:
                 for ctx, payload in ctx_payloads.items():
@@ -50,7 +53,7 @@ async def fan_out_to_ctxs(
                         await ctx.send_yield(payload)
                     except (
                         # That's right, anything you can think of...
-                        trio.ClosedStreamError, ConnectionResetError,
+                        trio.ClosedResourceError, ConnectionResetError,
                         ConnectionRefusedError,
                     ):
                         log.warning(f"{ctx.chan} went down?")


### PR DESCRIPTION
`trio` deprecated the old `Queue` in `0.11.0` and introduced the new [`trio.open_memory_channel()`](https://trio.readthedocs.io/en/latest/reference-core.html#using-channels-to-pass-values-between-tasks) system. Adopt this throughout the core and adjust all tests.

In other fun news, we were also suffering from a super subtle bug in Python itself, namely:
https://bugs.python.org/issue32526

This was the root cause of a slew of issues in some UI work in `piker`.

It turns out (at least with `trio`) asyn gen functions are **not** task safe and can cause all sorts of strange issues if operated on by multiple tasks. Thanks to [in depth diagnosis on the gitter channel](https://gitter.im/python-trio/general?at=5c65bb42dc3f0523ccb6a1ac), the alternative is to introduce an async iterator derivative of `trio.abc.ReceiveChannel` which wraps an underlying receive memory channel: the deliverer of iter-actor messages to actor-local tasks.

Todo: 
- update docs examples to use memchans
- limit `trio` to `> 0.10.0`?
 

Ping @oremanj @njsmith @vodik!
Please feel free to tear this right apart.

@oremanj @njsmith the main part I would very much appreciate your eyes on is the new [async iterator wrapper](https://github.com/tgoodlet/tractor/pull/56/files#diff-bddc99a980cb82e92f51b91e449918bfR51).